### PR TITLE
Updated to use cloudsmith

### DIFF
--- a/terraform-deployments/deployments/cas-mgr-load-balancer-one-ip-nat/default-vars.tf
+++ b/terraform-deployments/deployments/cas-mgr-load-balancer-one-ip-nat/default-vars.tf
@@ -25,11 +25,6 @@ variable "centos_admin_username" {
   default     = "centos_admin"
 }
 
-variable "pcoip_agent_location" {
-  description = "URL of Teradici PCoIP Standard Agent"
-  default     = "https://downloads.teradici.com/win/stable/"
-}
-
 variable "active_directory_netbios_name" {
   description = "The netbios name of the Active Directory domain, for example `consoto`"
   default     = "tera"

--- a/terraform-deployments/deployments/cas-mgr-one-ip-traffic-mgr/default-vars.tf
+++ b/terraform-deployments/deployments/cas-mgr-one-ip-traffic-mgr/default-vars.tf
@@ -25,11 +25,6 @@ variable "centos_admin_username" {
   default     = "centos_admin"
 }
 
-variable "pcoip_agent_location" {
-  description = "URL of Teradici PCoIP Standard Agent"
-  default     = "https://downloads.teradici.com/win/stable/"
-}
-
 variable "active_directory_netbios_name" {
   description = "The netbios name of the Active Directory domain, for example `consoto`"
   default     = "tera"

--- a/terraform-deployments/deployments/cas-mgr-single-connector/default-vars.tf
+++ b/terraform-deployments/deployments/cas-mgr-single-connector/default-vars.tf
@@ -35,11 +35,6 @@ variable "cas_mgr_url" {
   default     = "https://cam.teradici.com"
 }
 
-variable "pcoip_agent_location" {
-  description = "URL of Teradici PCoIP Standard Agent"
-  default     = "https://downloads.teradici.com/win/stable/"
-}
-
 variable "active_directory_netbios_name" {
   description = "The netbios name of the Active Directory domain, for example `consoto`"
   default     = "tera"

--- a/terraform-deployments/deployments/casm-aadds-one-ip-lb/default-vars.tf
+++ b/terraform-deployments/deployments/casm-aadds-one-ip-lb/default-vars.tf
@@ -41,11 +41,6 @@ variable "cas_mgr_url" {
   default     = "https://cam.teradici.com"
 }
 
-variable "pcoip_agent_location" {
-  description = "URL of Teradici PCoIP Standard Agent"
-  default     = "https://downloads.teradici.com/win/stable/"
-}
-
 variable "active_directory_netbios_name" {
   description = "The netbios name of the Active Directory domain, for example `consoto`"
   default     = "tera"

--- a/terraform-deployments/deployments/casm-aadds-one-ip-traffic-manager/default-vars.tf
+++ b/terraform-deployments/deployments/casm-aadds-one-ip-traffic-manager/default-vars.tf
@@ -41,11 +41,6 @@ variable "cas_mgr_url" {
   default     = "https://cam.teradici.com"
 }
 
-variable "pcoip_agent_location" {
-  description = "URL of Teradici PCoIP Standard Agent"
-  default     = "https://downloads.teradici.com/win/stable/"
-}
-
 variable "active_directory_netbios_name" {
   description = "The netbios name of the Active Directory domain, for example `consoto`"
   default     = "tera"

--- a/terraform-deployments/deployments/casm-aadds-single-connector/default-vars.tf
+++ b/terraform-deployments/deployments/casm-aadds-single-connector/default-vars.tf
@@ -41,11 +41,6 @@ variable "cas_mgr_url" {
   default     = "https://cam.teradici.com"
 }
 
-variable "pcoip_agent_location" {
-  description = "URL of Teradici PCoIP Standard Agent"
-  default     = "https://downloads.teradici.com/win/stable/"
-}
-
 variable "active_directory_netbios_name" {
   description = "The netbios name of the Active Directory domain, for example `consoto`"
   default     = "tera"

--- a/terraform-deployments/deployments/load-balancer-one-ip/default-vars.tf
+++ b/terraform-deployments/deployments/load-balancer-one-ip/default-vars.tf
@@ -40,11 +40,6 @@ variable "workstation_subnet_name" {
   default     = "workstation-subnet"
 }
 
-variable "pcoip_agent_location" {
-  description = "URL of Teradici PCoIP Standard Agent"
-  default     = "https://downloads.teradici.com/win/stable/"
-}
-
 variable "active_directory_netbios_name" {
   description = "The netbios name of the Active Directory domain, for example `consoto`"
   default     = "tera"

--- a/terraform-deployments/deployments/multi-region-traffic-mgr-one-ip/default-vars.tf
+++ b/terraform-deployments/deployments/multi-region-traffic-mgr-one-ip/default-vars.tf
@@ -30,11 +30,6 @@ variable "centos_admin_username" {
   default     = "centos_admin"
 }
 
-variable "pcoip_agent_location" {
-  description = "URL of Teradici PCoIP Standard Agent"
-  default     = "https://downloads.teradici.com/win/stable/"
-}
-
 variable "active_directory_netbios_name" {
   description = "The netbios name of the Active Directory domain, for example `consoto`"
   default     = "tera"

--- a/terraform-deployments/deployments/single-connector/default-vars.tf
+++ b/terraform-deployments/deployments/single-connector/default-vars.tf
@@ -40,11 +40,6 @@ variable "workstation_subnet_name" {
   default     = "workstation-subnet"
 }
 
-variable "pcoip_agent_location" {
-  description = "URL of Teradici PCoIP Standard Agent"
-  default     = "https://downloads.teradici.com/win/stable/"
-}
-
 variable "active_directory_netbios_name" {
   description = "The netbios name of the Active Directory domain, for example `consoto`"
   default     = "tera"

--- a/terraform-deployments/modules/aadds-mgmt/aadds-std-provisioning.ps1
+++ b/terraform-deployments/modules/aadds-mgmt/aadds-std-provisioning.ps1
@@ -49,8 +49,8 @@ param(
 
 $AgentLocation = 'C:\Program Files\Teradici\PCoIP Agent\'
 $LOG_FILE = "C:\Teradici\provisioning.log"
-$PCOIP_AGENT_FILENAME = ""
-$PCOIP_AGENT_LOCATION_URL = "https://downloads.teradici.com/win/stable/"
+$TERADICI_DOWNLOAD_TOKEN = "yj39yHtgj68Uv2Qf"
+$PCOIP_AGENT_LOCATION_URL = "https://dl.teradici.com/${TERADICI_DOWNLOAD_TOKEN}/pcoip-agent/raw/names/pcoip-agent-standard-exe/versions/latest/"
 
 $DATA = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
 $DATA.Add("pcoip_registration_code", "${pcoip_registration_code}")
@@ -129,20 +129,7 @@ function PCoIP-Agent-Install {
     }
 
     $agentInstallerDLDirectory = "C:\Teradici"
-    if (![string]::IsNullOrEmpty($PCOIP_AGENT_FILENAME)) {
-        "--> Using user-specified PCoIP standard agent filename..."
-        $agent_filename = $PCOIP_AGENT_FILENAME
-    }
-    else {
-        "--> Using default latest PCoIP standard agent..."
-        $agent_latest = $PCOIP_AGENT_LOCATION_URL + "latest-standard-agent.json"
-        $wc = New-Object System.Net.WebClient
-
-        "--> Checking for the latest PCoIP standard agent version from $agent_latest..."
-        $string = Retry -Action { $wc.DownloadString($agent_latest) }
-
-        $agent_filename = $string | ConvertFrom-Json | Select-Object -ExpandProperty "filename"
-    }
+    $agent_filename = "pcoip-agent-standard_latest.exe"
     $pcoipAgentInstallerUrl = $PCOIP_AGENT_LOCATION_URL + $agent_filename
     $destFile = $agentInstallerDLDirectory + '\' + $agent_filename
     $wc = New-Object System.Net.WebClient

--- a/terraform-deployments/modules/aadds-mgmt/windows-std-provisioning.ps1
+++ b/terraform-deployments/modules/aadds-mgmt/windows-std-provisioning.ps1
@@ -49,8 +49,8 @@ param(
 
 $AgentLocation = 'C:\Program Files\Teradici\PCoIP Agent\'
 $LOG_FILE = "C:\Teradici\provisioning.log"
-$PCOIP_AGENT_FILENAME = ""
-$PCOIP_AGENT_LOCATION_URL = "https://downloads.teradici.com/win/stable/"
+$TERADICI_DOWNLOAD_TOKEN = "yj39yHtgj68Uv2Qf"
+$PCOIP_AGENT_LOCATION_URL = "https://dl.teradici.com/${TERADICI_DOWNLOAD_TOKEN}/pcoip-agent/raw/names/pcoip-agent-standard-exe/versions/latest/"
 
 $DATA = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
 $DATA.Add("pcoip_registration_code", "${pcoip_registration_code}")
@@ -129,20 +129,7 @@ function PCoIP-Agent-Install {
     }
 
     $agentInstallerDLDirectory = "C:\Teradici"
-    if (![string]::IsNullOrEmpty($PCOIP_AGENT_FILENAME)) {
-        "--> Using user-specified PCoIP standard agent filename..."
-        $agent_filename = $PCOIP_AGENT_FILENAME
-    }
-    else {
-        "--> Using default latest PCoIP standard agent..."
-        $agent_latest = $PCOIP_AGENT_LOCATION_URL + "latest-standard-agent.json"
-        $wc = New-Object System.Net.WebClient
-
-        "--> Checking for the latest PCoIP standard agent version from $agent_latest..."
-        $string = Retry -Action { $wc.DownloadString($agent_latest) }
-
-        $agent_filename = $string | ConvertFrom-Json | Select-Object -ExpandProperty "filename"
-    }
+    $agent_filename = "pcoip-agent-standard_latest.exe"
     $pcoipAgentInstallerUrl = $PCOIP_AGENT_LOCATION_URL + $agent_filename
     $destFile = $agentInstallerDLDirectory + '\' + $agent_filename
     $wc = New-Object System.Net.WebClient

--- a/terraform-deployments/modules/centos-gfx-vm/centos-gfx-provisioning.sh.tmpl
+++ b/terraform-deployments/modules/centos-gfx-vm/centos-gfx-provisioning.sh.tmpl
@@ -5,11 +5,11 @@
 
 #!/bin/bash
 
-PCOIP_AGENT_REPO_PUBKEY_URL="https://downloads.teradici.com/rhel/teradici.pub.gpg"
-PCOIP_AGENT_REPO_URL="https://downloads.teradici.com/rhel/pcoip.repo"
 INST_LOG_PATH="/var/log/teradici/agent/"
 INST_LOG_FILE="/var/log/teradici/agent/install.log"
 DETAILED_LOG_FILE="/var/log/teradici/agent/detailed.log"
+TERADICI_DOWNLOAD_TOKEN=${teradici_download_token}
+TERADICI_REPO_SETUP_SCRIPT_URL="https://dl.teradici.com/$TERADICI_DOWNLOAD_TOKEN/pcoip-agent/cfg/setup/bash.rpm.sh"
 
 ENABLE_AUTO_SHUTDOWN=${enable_workstation_idle_shutdown}
 AUTO_SHUTDOWN_IDLE_TIMER=${minutes_idle_before_shutdown}
@@ -191,56 +191,47 @@ enable_persistence_mode() {
 }
 
 install_pcoip_agent() {
-    if ! (rpm -q pcoip-agent-graphics)
+    log "--> Getting Teradici PCoIP agent repo..."
+    curl --retry 3 --retry-delay 5 -u "token:$TERADICI_DOWNLOAD_TOKEN" -1sLf $TERADICI_REPO_SETUP_SCRIPT_URL | bash
+    if [ $? -ne 0 ]
     then
-        log "--> Installing PCoIP agent..."
-        # Get the Teradici pubkey
-        log "--> Getting Teradici pubkey..."
-        rpm --import $PCOIP_AGENT_REPO_PUBKEY_URL
+        log "--> ERROR: Failed to install PCoIP agent repo."
+        exit 1
+    fi
+    log "--> PCoIP agent repo installed successfully."
 
-        # Get PCoIP repo
-        log "--> Getting Teradici PCoIP agent repo..."
-        wget --retry-connrefused --tries=3 --waitretry=5 -P /etc/yum.repos.d $PCOIP_AGENT_REPO_URL
+    log "--> Installing USB dependencies..."
+    retry "yum install -y usb-vhci"
+    if [ $? -ne 0 ]; then
+        log "--> Warning: Failed to install usb-vhci."
+    fi
+    log "--> usb-vhci successfully installed."
 
-        log "--> Installing USB dependencies..."
-        retry "yum install -y usb-vhci"
-        if [ $? -ne 0 ]; then
-            log "--> Warning: Failed to install usb-vhci."
-        fi
-        log "--> usb-vhci successfully installed."
+    log "--> Installing PCoIP graphics agent..."
+    retry yum -y install pcoip-agent-graphics
+    if [ $? -ne 0 ]; then
+        log "--> ERROR: Failed to install PCoIP agent."
+        exit 1
+    fi
+    log "--> PCoIP agent installed successfully."
 
-        log "--> Installing PCoIP graphics agent..."
-        yum -y install pcoip-agent-graphics
-        if [ $? -ne 0 ]; then
-            log "--> ERROR: Failed to install PCoIP agent."
+    log "--> Registering PCoIP agent license..."
+    n=0
+    set +x
+    while true; do
+        /usr/sbin/pcoip-register-host --registration-code="$PCOIP_REGISTRATION_CODE" && break
+        n=$[$n+1]
+
+        if [ $n -ge 10 ]; then
+            log "--> ERROR: Failed to register PCoIP agent after $n tries."
             exit 1
         fi
-        log "--> PCoIP agent installed successfully."
 
-        set +x
-        if [[ "$PCOIP_REGISTRATION_CODE" ]]; then
-            log "--> Registering PCoIP agent license..."
-
-            n=0
-            while true; do
-                /usr/sbin/pcoip-register-host --registration-code="$PCOIP_REGISTRATION_CODE" && break
-                n=$[$n+1]
-
-                if [ $n -ge 10 ]; then
-                    log "--> ERROR: Failed to register PCoIP agent after $n tries."
-                    exit 1
-                fi
-
-                log "--> ERROR: Failed to register PCoIP agent. Retrying in 10s..."
-                sleep 10
-            done
-            log "--> PCoIP agent registered successfully."
-
-        else
-            log "--> No PCoIP Registration Code provided. Skipping PCoIP agent registration..."
-        fi
-        set -x
-    fi
+        log "--> ERROR: Failed to register PCoIP agent. Retrying in 10s..."
+        sleep 10
+    done
+    set -x
+    log "--> PCoIP agent registered successfully."
 }
 
 install_idle_shutdown() {

--- a/terraform-deployments/modules/centos-gfx-vm/default-vars.tf
+++ b/terraform-deployments/modules/centos-gfx-vm/default-vars.tf
@@ -11,6 +11,11 @@ variable "centos_gfx_depends_on" {
   default     = null
 }
 
+variable "teradici_download_token" {
+  description = "Token used to download from Teradici"
+  default     = "yj39yHtgj68Uv2Qf"
+}
+
 variable "enable_workstation_idle_shutdown" {
   description = "Enable Cloud Access Manager auto idle shutdown for Workstations"
   default     = true

--- a/terraform-deployments/modules/centos-gfx-vm/main.tf
+++ b/terraform-deployments/modules/centos-gfx-vm/main.tf
@@ -107,6 +107,7 @@ resource "azurerm_virtual_machine_extension" "centos-gfx-provisioning" {
   application_id                   = var.application_id,
   aad_client_secret                = var.aad_client_secret,
   tenant_id                        = var.tenant_id,
+  teradici_download_token          = var.teradici_download_token
   nvidia_driver_url                = var.nvidia_driver_url,
   enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown,
   minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval,
@@ -117,4 +118,3 @@ resource "azurerm_virtual_machine_extension" "centos-gfx-provisioning" {
   }
   SETTINGS
 }
-

--- a/terraform-deployments/modules/centos-std-vm/centos-std-provisioning.sh.tmpl
+++ b/terraform-deployments/modules/centos-std-vm/centos-std-provisioning.sh.tmpl
@@ -9,8 +9,8 @@
 INST_LOG_PATH="/var/log/teradici/agent/"
 INST_LOG_FILE="/var/log/teradici/agent/install.log"
 DETAILED_LOG_FILE="/var/log/teradici/agent/detailed.log"
-PCOIP_AGENT_REPO_PUBKEY_URL="https://downloads.teradici.com/rhel/teradici.pub.gpg"
-PCOIP_AGENT_REPO_URL="https://downloads.teradici.com/rhel/pcoip.repo"
+TERADICI_DOWNLOAD_TOKEN=${teradici_download_token}
+TERADICI_REPO_SETUP_SCRIPT_URL="https://dl.teradici.com/$TERADICI_DOWNLOAD_TOKEN/pcoip-agent/cfg/setup/bash.rpm.sh"
 
 ENABLE_AUTO_SHUTDOWN=${enable_workstation_idle_shutdown}
 AUTO_SHUTDOWN_IDLE_TIMER=${minutes_idle_before_shutdown}
@@ -65,55 +65,46 @@ get_credentials() {
 }
 
 install_pcoip_agent() {
-    if ! (rpm -q pcoip-agent-standard)
-    then
-        log "--> Installing PCoIP agent..."
-        # Get the Teradici pubkey
-        log "--> Getting Teradici pubkey..."
-        rpm --import $PCOIP_AGENT_REPO_PUBKEY_URL
+    log "--> Getting Teradici PCoIP agent repo..."
+    curl --retry 3 --retry-delay 5 -u "token:$TERADICI_DOWNLOAD_TOKEN" -1sLf $TERADICI_REPO_SETUP_SCRIPT_URL | bash
+    if [ $? -ne 0 ]; then
+        log "--> ERROR: Failed to install PCoIP agent repo."
+        exit 1
+    fi
+    log "--> PCoIP agent repo installed successfully."
 
-        # Get pcoip repo
-        log "--> Get Teradici PCoIP agent repo"
-        wget --retry-connrefused --tries=3 --waitretry=5 -O /etc/yum.repos.d/pcoip.repo $PCOIP_AGENT_REPO_URL
+    log "--> Installing USB dependencies..."
+    retry "yum install -y usb-vhci"
+    if [ $? -ne 0 ]; then
+        log "--> Warning: Failed to install usb-vhci."
+    fi
+    log "--> usb-vhci successfully installed."
 
-        log "--> Installing USB dependencies..."
-        retry "yum install -y usb-vhci"
-        if [ $? -ne 0 ]; then
-            log "--> Warning: Failed to install usb-vhci."
-        fi
-        log "--> usb-vhci successfully installed."
+    log "--> Installing PCoIP standard agent..."
+    retry yum -y install pcoip-agent-standard
+    if [ $? -ne 0 ]; then
+        log "--> ERROR: Failed to install PCoIP agent."
+        exit 1
+    fi
+    log "--> PCoIP agent installed successfully."
 
-        log "--> Install PCoIP standard agent ..."
-        dnf -y install pcoip-agent-standard
-        if [ $? -ne 0 ]; then
-            log "--> Failed to install PCoIP agent."
+    log "--> Registering PCoIP agent license..."
+    n=0
+    set +x
+    while true; do
+        /usr/sbin/pcoip-register-host --registration-code="$PCOIP_REGISTRATION_CODE" && break
+        n=$[$n+1]
+
+        if [ $n -ge 10 ]; then
+            log "--> ERROR: Failed to register PCoIP agent after $n tries."
             exit 1
         fi
-        log "--> PCoIP agent installed successfully."
 
-        set +x
-        if [[ "$PCOIP_REGISTRATION_CODE" ]]; then
-            log "--> Registering PCoIP agent license..."
-            n=0
-            while true; do
-                /usr/sbin/pcoip-register-host --registration-code="$PCOIP_REGISTRATION_CODE" && break
-                log "--> $?"
-                n=$[$n+1]
-
-                if [ $n -ge 10 ]; then
-                    log "--> Failed to register PCoIP agent after $n tries."
-                    exit 1
-                fi
-
-                log "--> Failed to register PCoIP agent. Retrying in 10s..."
-                sleep 10
-            done
-            log "--> PCoIP agent registered successfully."
-        else
-            log "--> No PCoIP Registration Code provided. Skipping PCoIP agent registration..."
-        fi
-        set -x
-    fi
+        log "--> ERROR: Failed to register PCoIP agent. Retrying in 10s..."
+        sleep 10
+    done
+    set -x
+    log "--> PCoIP agent registered successfully."
 }
 
 install_idle_shutdown() {

--- a/terraform-deployments/modules/centos-std-vm/default-vars.tf
+++ b/terraform-deployments/modules/centos-std-vm/default-vars.tf
@@ -11,6 +11,11 @@ variable "centos_std_depends_on" {
   default     = null
 }
 
+variable "teradici_download_token" {
+  description = "Token used to download from Teradici"
+  default     = "yj39yHtgj68Uv2Qf"
+}
+
 variable "enable_workstation_idle_shutdown" {
   description = "Enable Cloud Access Manager auto idle shutdown for Workstations"
   default     = true

--- a/terraform-deployments/modules/centos-std-vm/main.tf
+++ b/terraform-deployments/modules/centos-std-vm/main.tf
@@ -106,6 +106,7 @@ resource "azurerm_virtual_machine_extension" "centos-std-provisioning" {
   application_id                   = var.application_id,
   aad_client_secret                = var.aad_client_secret,
   tenant_id                        = var.tenant_id,
+  teradici_download_token          = var.teradici_download_token
   enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown,
   minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval,
   minutes_idle_before_shutdown     = var.minutes_idle_before_shutdown
@@ -115,4 +116,3 @@ resource "azurerm_virtual_machine_extension" "centos-std-provisioning" {
   }
   SETTINGS
 }
-

--- a/terraform-deployments/modules/lls/lls-provisioning.sh.tmpl
+++ b/terraform-deployments/modules/lls/lls-provisioning.sh.tmpl
@@ -10,6 +10,7 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 LOG_FILE="/var/log/teradici/provisioning.log"
 
 LLS_YUM_PKG="pcoip-license-server"
+LLS_REPO_SETUP_SCRIPT_URL="https://dl.teradici.com/${teradici_download_token}/pcoip-license-server/cfg/setup/bash.rpm.sh"
 
 LLS_ADMIN_PASSWORD=${lls_admin_password}
 LLS_ACTIVATION_CODE=${lls_activation_code}
@@ -96,7 +97,7 @@ get_credentials
 
 check_required_vars
 
-yum install -y ${lls_repo_url}
+curl -1sLf $LLS_REPO_SETUP_SCRIPT_URL | bash
 yum install -y $LLS_YUM_PKG
 
 set +x

--- a/terraform-deployments/modules/lls/main.tf
+++ b/terraform-deployments/modules/lls/main.tf
@@ -88,17 +88,16 @@ resource "azurerm_virtual_machine_extension" "lls-provisioning" {
   protected_settings = <<SETTINGS
   {
   "script": "${base64encode(templatefile("${path.module}/${local.lls_provisioning_script}.tmpl", {
-  lls_repo_url        = var.lls_repo_url,
-  lls_admin_password  = var.lls_admin_password,
-  lls_activation_code = var.lls_activation_code,
-  lls_license_count   = var.lls_license_count,
-  application_id              = var.application_id
-  aad_client_secret           = var.aad_client_secret
-  tenant_id                   = var.tenant_id
+  teradici_download_token = var.teradici_download_token,
+  lls_admin_password      = var.lls_admin_password,
+  lls_activation_code     = var.lls_activation_code,
+  lls_license_count       = var.lls_license_count,
+  application_id          = var.application_id
+  aad_client_secret       = var.aad_client_secret
+  tenant_id               = var.tenant_id
 })
 )
 }"
     }
   SETTINGS
 }
-

--- a/terraform-deployments/modules/lls/vars.tf
+++ b/terraform-deployments/modules/lls/vars.tf
@@ -50,9 +50,9 @@ variable "host_name" {
   default     = "lls-vm"
 }
 
-variable "lls_repo_url" {
-  description = "Location of the Teradici License Server RPM repo"
-  default     = "https://downloads.teradici.com/rhel/teradici-repo-latest.noarch.rpm"
+variable "teradici_download_token" {
+  description = "Token used to download from Teradici"
+  default     = "yj39yHtgj68Uv2Qf"
 }
 
 variable "lls_admin_password" {

--- a/terraform-deployments/modules/windows-gfx-vm/windows-gfx-provisioning-aadds.ps1
+++ b/terraform-deployments/modules/windows-gfx-vm/windows-gfx-provisioning-aadds.ps1
@@ -58,8 +58,8 @@ param(
 $AgentLocation = 'C:\Program Files\Teradici\PCoIP Agent\'
 $LOG_FILE = "C:\Teradici\provisioning.log"
 $NVIDIA_DIR = "C:\Program Files\NVIDIA Corporation\NVSMI"
-$PCOIP_AGENT_FILENAME = ""
-$PCOIP_AGENT_LOCATION_URL = "https://downloads.teradici.com/win/stable/"
+$TERADICI_DOWNLOAD_TOKEN = "yj39yHtgj68Uv2Qf"
+$PCOIP_AGENT_LOCATION_URL = "https://dl.teradici.com/${TERADICI_DOWNLOAD_TOKEN}/pcoip-agent/raw/names/pcoip-agent-standard-exe/versions/latest/"
 
 $DATA = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
 $DATA.Add("pcoip_registration_code", "${pcoip_registration_code}")
@@ -183,20 +183,7 @@ function PCoIP-Agent-Install {
     }
 
     $agentInstallerDLDirectory = "C:\Teradici"
-    if (![string]::IsNullOrEmpty($PCOIP_AGENT_FILENAME)) {
-        "--> Using user-specified PCoIP graphics agent filename..."
-        $agent_filename = $PCOIP_AGENT_FILENAME
-    }
-    else {
-        "--> Using default latest PCoIP graphics agent..."
-        $agent_latest = $PCOIP_AGENT_LOCATION_URL + "latest-graphics-agent.json"
-        $wc = New-Object System.Net.WebClient
-
-        "--> Checking for the latest PCoIP graphics agent version from $agent_latest..."
-        $string = Retry -Action { $wc.DownloadString($agent_latest) }
-
-        $agent_filename = $string | ConvertFrom-Json | Select-Object -ExpandProperty "filename"
-    }
+    $agent_filename = "pcoip-agent-graphics_latest.exe"
     $pcoipAgentInstallerUrl = $PCOIP_AGENT_LOCATION_URL + $agent_filename
     $destFile = $agentInstallerDLDirectory + '\' + $agent_filename
     $wc = New-Object System.Net.WebClient

--- a/terraform-deployments/modules/windows-gfx-vm/windows-gfx-provisioning.ps1
+++ b/terraform-deployments/modules/windows-gfx-vm/windows-gfx-provisioning.ps1
@@ -58,8 +58,8 @@ param(
 $AgentLocation = 'C:\Program Files\Teradici\PCoIP Agent\'
 $LOG_FILE = "C:\Teradici\provisioning.log"
 $NVIDIA_DIR = "C:\Program Files\NVIDIA Corporation\NVSMI"
-$PCOIP_AGENT_FILENAME = ""
-$PCOIP_AGENT_LOCATION_URL = "https://downloads.teradici.com/win/stable/"
+$TERADICI_DOWNLOAD_TOKEN = "yj39yHtgj68Uv2Qf"
+$PCOIP_AGENT_LOCATION_URL = "https://dl.teradici.com/${TERADICI_DOWNLOAD_TOKEN}/pcoip-agent/raw/names/pcoip-agent-standard-exe/versions/latest/"
 
 $DATA = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
 $DATA.Add("pcoip_registration_code", "${pcoip_registration_code}")
@@ -183,20 +183,7 @@ function PCoIP-Agent-Install {
     }
 
     $agentInstallerDLDirectory = "C:\Teradici"
-    if (![string]::IsNullOrEmpty($PCOIP_AGENT_FILENAME)) {
-        "--> Using user-specified PCoIP graphics agent filename..."
-        $agent_filename = $PCOIP_AGENT_FILENAME
-    }
-    else {
-        "--> Using default latest PCoIP graphics agent..."
-        $agent_latest = $PCOIP_AGENT_LOCATION_URL + "latest-graphics-agent.json"
-        $wc = New-Object System.Net.WebClient
-
-        "--> Checking for the latest PCoIP graphics agent version from $agent_latest..."
-        $string = Retry -Action { $wc.DownloadString($agent_latest) }
-
-        $agent_filename = $string | ConvertFrom-Json | Select-Object -ExpandProperty "filename"
-    }
+    $agent_filename = "pcoip-agent-graphics_latest.exe"
     $pcoipAgentInstallerUrl = $PCOIP_AGENT_LOCATION_URL + $agent_filename
     $destFile = $agentInstallerDLDirectory + '\' + $agent_filename
     $wc = New-Object System.Net.WebClient

--- a/terraform-deployments/modules/windows-std-vm/windows-std-provisioning-aadds.ps1
+++ b/terraform-deployments/modules/windows-std-vm/windows-std-provisioning-aadds.ps1
@@ -49,8 +49,8 @@ param(
 
 $AgentLocation = 'C:\Program Files\Teradici\PCoIP Agent\'
 $LOG_FILE = "C:\Teradici\provisioning.log"
-$PCOIP_AGENT_FILENAME = ""
-$PCOIP_AGENT_LOCATION_URL = "https://downloads.teradici.com/win/stable/"
+$TERADICI_DOWNLOAD_TOKEN = "yj39yHtgj68Uv2Qf"
+$PCOIP_AGENT_LOCATION_URL = "https://dl.teradici.com/${TERADICI_DOWNLOAD_TOKEN}/pcoip-agent/raw/names/pcoip-agent-standard-exe/versions/latest/"
 
 $DATA = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
 $DATA.Add("pcoip_registration_code", "${pcoip_registration_code}")
@@ -129,20 +129,7 @@ function PCoIP-Agent-Install {
     }
 
     $agentInstallerDLDirectory = "C:\Teradici"
-    if (![string]::IsNullOrEmpty($PCOIP_AGENT_FILENAME)) {
-        "--> Using user-specified PCoIP standard agent filename..."
-        $agent_filename = $PCOIP_AGENT_FILENAME
-    }
-    else {
-        "--> Using default latest PCoIP standard agent..."
-        $agent_latest = $PCOIP_AGENT_LOCATION_URL + "latest-standard-agent.json"
-        $wc = New-Object System.Net.WebClient
-
-        "--> Checking for the latest PCoIP standard agent version from $agent_latest..."
-        $string = Retry -Action { $wc.DownloadString($agent_latest) }
-
-        $agent_filename = $string | ConvertFrom-Json | Select-Object -ExpandProperty "filename"
-    }
+    $agent_filename = "pcoip-agent-standard_latest.exe"
     $pcoipAgentInstallerUrl = $PCOIP_AGENT_LOCATION_URL + $agent_filename
     $destFile = $agentInstallerDLDirectory + '\' + $agent_filename
     $wc = New-Object System.Net.WebClient

--- a/terraform-deployments/modules/windows-std-vm/windows-std-provisioning.ps1
+++ b/terraform-deployments/modules/windows-std-vm/windows-std-provisioning.ps1
@@ -49,8 +49,8 @@ param(
 
 $AgentLocation = 'C:\Program Files\Teradici\PCoIP Agent\'
 $LOG_FILE = "C:\Teradici\provisioning.log"
-$PCOIP_AGENT_FILENAME = ""
-$PCOIP_AGENT_LOCATION_URL = "https://downloads.teradici.com/win/stable/"
+$TERADICI_DOWNLOAD_TOKEN = "yj39yHtgj68Uv2Qf"
+$PCOIP_AGENT_LOCATION_URL = "https://dl.teradici.com/${TERADICI_DOWNLOAD_TOKEN}/pcoip-agent/raw/names/pcoip-agent-standard-exe/versions/latest/"
 
 $DATA = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
 $DATA.Add("pcoip_registration_code", "${pcoip_registration_code}")
@@ -129,20 +129,7 @@ function PCoIP-Agent-Install {
     }
 
     $agentInstallerDLDirectory = "C:\Teradici"
-    if (![string]::IsNullOrEmpty($PCOIP_AGENT_FILENAME)) {
-        "--> Using user-specified PCoIP standard agent filename..."
-        $agent_filename = $PCOIP_AGENT_FILENAME
-    }
-    else {
-        "--> Using default latest PCoIP standard agent..."
-        $agent_latest = $PCOIP_AGENT_LOCATION_URL + "latest-standard-agent.json"
-        $wc = New-Object System.Net.WebClient
-
-        "--> Checking for the latest PCoIP standard agent version from $agent_latest..."
-        $string = Retry -Action { $wc.DownloadString($agent_latest) }
-
-        $agent_filename = $string | ConvertFrom-Json | Select-Object -ExpandProperty "filename"
-    }
+    $agent_filename = "pcoip-agent-standard_latest.exe"
     $pcoipAgentInstallerUrl = $PCOIP_AGENT_LOCATION_URL + $agent_filename
     $destFile = $agentInstallerDLDirectory + '\' + $agent_filename
     $wc = New-Object System.Net.WebClient


### PR DESCRIPTION
Replaced downloads.teradici.com with dl.teradici.com and updated methods
as necessary.

Removed unused variables referencing downloads.teradici.com

Signed-off-by: Daniel Bergel <daniel.bergel@hp.com>