### PR TITLE
Set storage account min TLS version to 1.0

### DIFF
--- a/terraform-deployments/deployments/cas-mgr-load-balancer-one-ip-nat/utility.tf
+++ b/terraform-deployments/deployments/cas-mgr-load-balancer-one-ip-nat/utility.tf
@@ -26,6 +26,7 @@ resource "azurerm_storage_account" "storage" {
   account_tier                    = "Standard"
   account_replication_type        = "LRS"
   allow_nested_items_to_be_public = true
+  min_tls_version                 = "TLS1_0"
 }
 
 resource "azurerm_storage_container" "blob" {

--- a/terraform-deployments/deployments/cas-mgr-one-ip-traffic-mgr/utility.tf
+++ b/terraform-deployments/deployments/cas-mgr-one-ip-traffic-mgr/utility.tf
@@ -26,6 +26,7 @@ resource "azurerm_storage_account" "storage" {
   account_tier                    = "Standard"
   account_replication_type        = "LRS"
   allow_nested_items_to_be_public = true
+  min_tls_version                 = "TLS1_0"
 }
 
 resource "azurerm_storage_container" "blob" {

--- a/terraform-deployments/deployments/cas-mgr-single-connector/utility.tf
+++ b/terraform-deployments/deployments/cas-mgr-single-connector/utility.tf
@@ -26,6 +26,7 @@ resource "azurerm_storage_account" "storage" {
   account_tier                    = "Standard"
   account_replication_type        = "LRS"
   allow_nested_items_to_be_public = true
+  min_tls_version                 = "TLS1_0"
 }
 
 resource "azurerm_storage_container" "blob" {

--- a/terraform-deployments/deployments/casm-aadds-one-ip-lb/utility.tf
+++ b/terraform-deployments/deployments/casm-aadds-one-ip-lb/utility.tf
@@ -40,6 +40,7 @@ resource "azurerm_storage_account" "storage" {
   account_tier                    = "Standard"
   account_replication_type        = "LRS"
   allow_nested_items_to_be_public = true
+  min_tls_version                 = "TLS1_0"
 }
 
 resource "azurerm_storage_container" "blob" {

--- a/terraform-deployments/deployments/casm-aadds-one-ip-traffic-manager/utility.tf
+++ b/terraform-deployments/deployments/casm-aadds-one-ip-traffic-manager/utility.tf
@@ -40,6 +40,7 @@ resource "azurerm_storage_account" "storage" {
   account_tier                    = "Standard"
   account_replication_type        = "LRS"
   allow_nested_items_to_be_public = true
+  min_tls_version                 = "TLS1_0"
 }
 
 resource "azurerm_storage_container" "blob" {

--- a/terraform-deployments/deployments/casm-aadds-single-connector/utility.tf
+++ b/terraform-deployments/deployments/casm-aadds-single-connector/utility.tf
@@ -40,6 +40,7 @@ resource "azurerm_storage_account" "storage" {
   account_tier                    = "Standard"
   account_replication_type        = "LRS"
   allow_nested_items_to_be_public = true
+  min_tls_version                 = "TLS1_0"
 }
 
 resource "azurerm_storage_container" "blob" {

--- a/terraform-deployments/deployments/lls-single-connector/main.tf
+++ b/terraform-deployments/deployments/lls-single-connector/main.tf
@@ -30,6 +30,7 @@ resource "azurerm_storage_account" "windows-script-storage" {
   account_tier                    = "Standard"
   account_replication_type        = "LRS"
   allow_nested_items_to_be_public = true
+  min_tls_version                 = "TLS1_0"
 }
 
 resource "azurerm_storage_container" "windows-script-blob" {

--- a/terraform-deployments/deployments/load-balancer-one-ip/main.tf
+++ b/terraform-deployments/deployments/load-balancer-one-ip/main.tf
@@ -30,6 +30,7 @@ resource "azurerm_storage_account" "windows-script-storage" {
   account_tier                    = "Standard"
   account_replication_type        = "LRS"
   allow_nested_items_to_be_public = true
+  min_tls_version                 = "TLS1_0"
 }
 
 resource "azurerm_storage_container" "windows-script-blob" {

--- a/terraform-deployments/deployments/multi-region-traffic-mgr-one-ip/utility.tf
+++ b/terraform-deployments/deployments/multi-region-traffic-mgr-one-ip/utility.tf
@@ -26,6 +26,7 @@ resource "azurerm_storage_account" "storage" {
   account_tier                    = "Standard"
   account_replication_type        = "LRS"
   allow_nested_items_to_be_public = true
+  min_tls_version                 = "TLS1_0"
 }
 
 resource "azurerm_storage_container" "blob" {

--- a/terraform-deployments/deployments/single-connector/main.tf
+++ b/terraform-deployments/deployments/single-connector/main.tf
@@ -30,6 +30,7 @@ resource "azurerm_storage_account" "windows-script-storage" {
   account_tier                    = "Standard"
   account_replication_type        = "LRS"
   allow_nested_items_to_be_public = true
+  min_tls_version                 = "TLS1_0"
 }
 
 resource "azurerm_storage_container" "windows-script-blob" {


### PR DESCRIPTION
Azurerm Terraform provider updates default min_tls_version on storage
accounts to 1.2, however this is incompatible with the local-exec
provisioners used for the Windows VMs.

Signed-off-by: Daniel Bergel <daniel.bergel@hp.com>