### PR TITLE
Cld 396 module var

### DIFF
--- a/terraform-deployments/check_sku_avail.py
+++ b/terraform-deployments/check_sku_avail.py
@@ -12,12 +12,15 @@
 #
 # TODO: add more flexibiility to CAC and CAS Manager VM checks.
 #
-# Last Updated: 07/20/2022
+# Last Updated: 07/21/2022
 
 import subprocess
 import time
 import re
 import argparse
+import pathlib
+
+PATH_TO_DIR = str(pathlib.Path(__file__).parent.resolve())
 
 # List of possible regions to search for VM sizes (all possibilities)
 REGIONS=["eastus", "eastus2", "southcentralus", "westus2", "westus3", "australiaeast",
@@ -48,20 +51,20 @@ DEPLOYMENTS=["cas-mgr-load-balancer-one-ip-nat",
              "single-connector"]
 
 # General logging of process
-LOG_FILE = "sku_availability_check.log"
+LOG_FILE = PATH_TO_DIR + "sku_availability_check.log"
 
 # File to collect availability statuses from Azure Cloud Shell commands
-VM_AVAILABILITY_FILE = "./current-sku-status.txt"
+VM_AVAILABILITY_FILE = PATH_TO_DIR + "/current-sku-status.txt"
 
 # Locations to find intended VM sizes for architecture components
-DEFAULT_CAC_VM_SIZE_FILES = ["./modules/cac-regional/vars.tf", "./modules/cac-regional-private/vars.tf"]
-DEFAULT_CASM_VM_SIZE_FILES = ["./modules/cas-mgr/vars.tf"]
-DEFAULT_DC_VM_SIZE_FILES = ["./modules/dc/dc-vm/default-vars.tf"]
+DEFAULT_CAC_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cac-regional/vars.tf", PATH_TO_DIR + "/modules/cac-regional-private/vars.tf"]
+DEFAULT_CASM_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cas-mgr/vars.tf"]
+DEFAULT_DC_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/dc/dc-vm/default-vars.tf"]
 
 # Locations to update if VM sizes are unavailable
-CAC_VM_SIZE_SET_FILES = ["./modules/cac-regional/main.tf", "./modules/cac-regional-private/main.tf"]
-CASM_VM_SIZE_SET_FILES = ["./modules/cas-mgr/main.tf"]
-DC_VM_SIZE_SET_FILES = ["./modules/dc/dc-vm/main.tf"]
+CAC_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/cac-regional/main.tf", PATH_TO_DIR + "/modules/cac-regional-private/main.tf"]
+CASM_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/cas-mgr/main.tf"]
+DC_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/dc/dc-vm/main.tf"]
 
 # Priority list of possible SKU sizes for Windows/Linux Standard Workstations (NOTE: prepend selected terraform.tfvars size to this list when checking availability)
 STANDARD_SKUS_PRIORITY = ["Standard_B2s", "Standard_B2ms", "Standard_D2s_v3", "Standard_B4ms", "Standard_DS2_v2", "Standard_D4s_v3", "Standard_B8ms", "Standard_DS3_v2"]
@@ -181,7 +184,7 @@ def set_sku_size(set_file, idx):
     log("File edit complete. Changes may be verified in " + set_file)
 
 def check_workstations_for_deployment(deployment):
-    tfvars_file = open("./deployments/" + deployment + "/terraform.tfvars", "r")
+    tfvars_file = open(PATH_TO_DIR + "/deployments/" + deployment + "/terraform.tfvars", "r")
 
     tfvars_file.close()
 
@@ -196,19 +199,24 @@ def assign_filenames(deployment):
     global DC_VM_SIZE_SET_FILES
 
     if deployment == "cas-mgr-single-connector":
-        # DEFAULT_CAC and CAC_VM should be checked
-        DEFAULT_CAC_VM_SIZE_FILES = ["./modules/cac-regional/vars.tf", "./modules/cac-regional-private/vars.tf"]
-        CAC_VM_SIZE_SET_FILES = ["./modules/cac-regional/main.tf", "./modules/cac-regional-private/main.tf"]
-
-        DEFAULT_CASM_VM_SIZE_FILES = ["./modules/cas-mgr/vars.tf"]
-        CASM_VM_SIZE_SET_FILES = ["./modules/cas-mgr/main.tf"]
-
-        DEFAULT_DC_VM_SIZE_FILES = ["./modules/dc/dc-vm/default-vars.tf"]
-        DC_VM_SIZE_SET_FILES = ["./modules/dc/dc-vm/main.tf"]
+       # Same as global variable initial values
+       pass
     if deployment == "cas-mgr-load-balancer-one-ip-nat":
-        pass
+
+        DEFAULT_CAC_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cac-regional/vars.tf", PATH_TO_DIR + "/modules/cac-regional-private-lb-nat/vars.tf"]
+        CAC_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/cac-regional/main.tf", PATH_TO_DIR + "/modules/cac-regional-private-lb-nat/main.tf"]
+
+        DEFAULT_CASM_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cas-mgr-lb-nat/vars.tf"]
+        CASM_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/cas-mgr-lb-nat/main.tf"]
+
     if deployment == "cas-mgr-one-ip-traffic-mgr":
-        pass
+        
+        DEFAULT_CAC_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cac-regional/vars.tf", PATH_TO_DIR + "/modules/cac-regional-private-lb-nat/vars.tf"]
+        CAC_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/cac-regional/main.tf", PATH_TO_DIR + "/modules/cac-regional-private-lb-nat/main.tf"]
+
+        DEFAULT_CASM_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cas-mgr-lb-nat/vars.tf"]
+        CASM_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/cas-mgr-lb-nat/main.tf"]
+
     if deployment == "casm-aadds":
         pass
     if deployment == "casm-aadds-one-ip-lb":

--- a/terraform-deployments/check_sku_avail.py
+++ b/terraform-deployments/check_sku_avail.py
@@ -1,0 +1,199 @@
+# HP Teradici Check SKU Availability
+#
+# This script was made as an additional optional step to help prevent issues regarding SKU availability under
+# Microsoft Azure subscriptions resulting in Terraform deployment errors.
+#
+# This script is meant to be run within the environment of the Azure Cloud Shell, and is not intended to be run
+# in a local environment.
+#
+# TODO: add more flexibiility to CAC and CAS Manager VM checks. Original creation of this script uses 
+# CAS Manager SaaS deployment var files.
+#
+# Last Updated: 07/15/2022
+
+import subprocess
+import time
+import re
+import argparse
+
+# List of possible regions to search for VM sizes (all possibilities)
+REGIONS=["eastus", "eastus2", "southcentralus", "westus2", "westus3", "australiaeast",
+         "southeastasia", "northeurope", "swedencentral", "uksouth", "westeurope", "centralus",
+         "southafricannorth", "centralindia", "eastasia", "japaneast", "koreacentral", "canadacentral",
+         "francecentral", "germanywestcentral", "norwayeast", "switzerlandnorth", "brazilsouth", "eastus2euap",
+         "centralusstage", "eastusstage", "eastus2stage", "northcentralusstage", "southcentralusstage",
+         "westusstage", "westus2stage", "asia", "asiapacific", "australia", "brazil", "canada", "europe",
+         "france", "germany", "global", "india", "japan", "korea", "norway", "singapore", "southafrica",
+         "switzerland", "uae", "uk", "unitedstates", "unitedstateseuap", "eastasiastage", "southeastasiastage",
+         "northcentralus", "westus", "jioindiawest", "uaenorth", "centraluseuap", "westcentralus", "southafricawest",
+         "australiacentral", "australiacentral2", "australiasoutheast", "japanwest", "jioindiacentral", "koreasouth",
+         "southindia", "westindia", "canadaeast", "francesouth", "germanynorth", "norwaywest", "switzerlandwest", "ukwest",
+         "uaecentral", "brazilsoutheast"]
+
+# General logging of process
+LOG_FILE = "sku_availability_check.log"
+
+# File to collect availability statuses from Azure Cloud Shell commands
+VM_AVAILABILITY_FILE = "./current-sku-status.txt"
+
+# Locations to find intended VM sizes for architecture components
+DEFAULT_CAC_VM_SIZE_FILE = "./modules/cac/cac-vm/default-vars.tf"
+DEFAULT_CASM_VM_SIZE_FILE = "./modules/cas-mgr/vars.tf"
+DEFAULT_DC_VM_SIZE_FILE = "./modules/dc/dc-vm/default-vars.tf"
+
+# Locations to update if VM sizes are unavailable
+CAC_VM_SIZE_SET_FILE = "./modules/cac/cac-vm/main.tf"
+CASM_VM_SIZE_SET_FILE = "./modules/cas-mgr/main.tf"
+DC_VM_SIZE_SET_FILE = "./modules/dc/dc-vm/main.tf"
+
+class MissingLocationError(Exception):
+    pass
+
+class MissingDefaultSizesError(Exception):
+    pass
+
+class InvalidSKUSizeError(Exception):
+    pass
+
+def log(msg):
+    temp = open(LOG_FILE, "a")
+    temp.write("[" + time.strftime("%Y-%m-%d %H:%M:%S") + "] " + msg + '\n')
+    temp.close()
+    print(msg)
+
+def extract_default_sizes(vm_type):
+    SIZE_FILE = None
+    VAR_LINE = ""
+
+    if vm_type == "CAC":
+        SIZE_FILE = DEFAULT_CAC_VM_SIZE_FILE
+        VAR_LINE = "variable \"machine_type\""
+    if vm_type == "CAS Manager":
+        SIZE_FILE = DEFAULT_CASM_VM_SIZE_FILE
+        VAR_LINE = "variable \"machine_type\""
+    if vm_type == "DC":
+        SIZE_FILE = DEFAULT_DC_VM_SIZE_FILE
+        VAR_LINE = "variable \"dc_machine_type\""
+
+    default_size_file = open(SIZE_FILE, 'r')
+    in_var_block = False
+    vm_sizes = []
+
+    for line in default_size_file:
+        if line.find(VAR_LINE) != -1:
+            in_var_block = True
+            continue
+        if line.find("default") != -1 and in_var_block and (line.find("#") == -1 or line.find("#") > line.find("default")):
+            vm_sizes = line[line.index("[")+1:line.index("]")].replace("[", "").replace("]", "").replace(", ", " ").replace("\"", "").split(" ")
+            log("Default values found for " + vm_type + ": " + str(vm_sizes))
+            break
+        if line.find("\}") != -1 and in_var_block:
+            log("Did not find any set values for the " + vm_type + ".")
+            raise MissingDefaultSizesError()
+    return vm_sizes
+
+
+def check_sku_sizes(vm_sizes, location):
+    sku_file = open(VM_AVAILABILITY_FILE, "w")
+    for i in range(len(vm_sizes)):
+        log("-- Checking availability of VM size " + vm_sizes[i])
+        sku_file.write(str(subprocess.check_output(["az", "vm", "list-skus", "--location", location, 
+                                                                             "--size", vm_sizes[i], 
+                                                                             "--all", 
+                                                                             "--output", "table"])).replace("\\n", '\n'))
+        # Separate the output of one command from the next
+        sku_file.write('\n')
+    sku_file.close()
+
+
+def determine_sku_size(vm_type, vm_sizes):
+    sku_file = open(VM_AVAILABILITY_FILE, "r")
+
+    log("Determining available size for " + vm_type + " under current Azure subscription...")
+    for i in range(len(vm_sizes)):
+        for line in sku_file:
+            if line.find(vm_sizes[i]) != -1:
+                if line.find("NotAvailableForSubscription") != -1:
+                    log("SKU size " + vm_sizes[i] + " is not available for this subscription")
+                    break
+                sku_file.close()
+                log("SKU size " + vm_sizes[i] + " is highest priority for " + vm_type + " that is available")
+                return i
+    
+    log("SKU sizes for " + vm_type + " did not return any information. Please check the list of sizes requested for this component or the region to search.")
+    raise InvalidSKUSizeError()
+
+def set_sku_size(set_file, idx):
+    edit_file = open(set_file, "r")
+    replacement = ""
+    for line in edit_file:
+        changes = re.sub('var.machine_type\[[0-9]*\]', 'var.machine_type[' + str(idx) + ']', line)
+        changes_cac = re.sub('var.cac_machine_type\[[0-9]*\]', 'var.cac_machine_type[' + str(idx) + ']', line)
+        changes_dc = re.sub('var.dc_machine_type\[[0-9]*\]', 'var.dc_machine_type[' + str(idx) + ']', line)
+
+        if line != changes_cac:
+            replacement += changes_cac
+            continue
+        if line != changes_dc:
+            replacement += changes_dc
+            continue
+        replacement += changes
+        
+    edit_file.close()
+
+    edit_filewrite = open(set_file, "w")
+    edit_filewrite.write(replacement)
+    edit_filewrite.close()
+
+    log("File edit complete. Changes may be verified in " + set_file)
+
+def main():
+    # Define parameters
+    # - location (required) : the region in which to check for SKU sizes; this should be specified as the same as the desired workstations' region
+    # - no_casm_vm          : whether or not the deployment will include CAS Manager as a separate VM; specify when indicating using CASM SaaS or other
+    # - no_ldc              : whether or not the deployment will require a Local Domain Controller; specify when indicating using Azure AD Domain Services
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-l", "--location", metavar="AAA", choices=REGIONS, required=True, help="Region to check for VM sizes")
+    parser.add_argument("--no-casm-vm", default=False, dest="no_casm_vm", 
+                        action='store_true', help="Flag for CAS Manager VM; True when using SaaS")
+    parser.add_argument("--no-ldc", default=False, dest="no_ldc", action='store_true', help="Flag for DC VM; True when using AADDS")
+    args = parser.parse_args()
+
+    open(VM_AVAILABILITY_FILE, "a+").close()
+
+    log("Querying for SKU sizes in location \"" + args.location + "\"")
+    # TODO: should be taking from cac/cac-vm/
+    # ... this varies depending on the deployment type, should we add a param for deployment types
+    log("Finding default SKU sizes for CAC-VM...")
+    cac_sizes = extract_default_sizes("CAC")
+    log("Checking availability of default CAC VM sizes...")
+    check_sku_sizes(cac_sizes, args.location)
+    available_sku_idx = determine_sku_size("CAC", cac_sizes)
+    log("Setting VM size index for CAC VM...")
+    set_sku_size(CAC_VM_SIZE_SET_FILE, available_sku_idx)
+
+    if not args.no_casm_vm:
+        # TODO: should be going from modules/cas-mgr-* based on deployment
+        log("Finding default SKU sizes for CAS Manager VM...")
+        casm_sizes = extract_default_sizes("CAS Manager")
+        log("Checking availability of default CAS Manager VM sizes...")
+        check_sku_sizes(casm_sizes, args.location)
+        available_sku_idx = determine_sku_size("CAS Manager", casm_sizes)
+        log("Setting VM size index for CAS Manager VM...")
+        set_sku_size(CASM_VM_SIZE_SET_FILE, available_sku_idx)
+
+    if not args.no_ldc:
+        log("Finding default SKU sizes for Domain Controller VM...")
+        dc_sizes = extract_default_sizes("DC")
+        log("Checking availability of default Domain Controller VM sizes...")
+        check_sku_sizes(dc_sizes, args.location)
+        available_sku_idx = determine_sku_size("DC", dc_sizes)
+        log("Setting VM size index for Domain Controller...")
+        set_sku_size(DC_VM_SIZE_SET_FILE, available_sku_idx)
+
+    subprocess.run(["rm", VM_AVAILABILITY_FILE])
+    log("SKU availability check completed.\n")
+
+if __name__ == "__main__":
+    main()

--- a/terraform-deployments/check_sku_avail.py
+++ b/terraform-deployments/check_sku_avail.py
@@ -9,7 +9,7 @@
 # TODO: add more flexibiility to CAC and CAS Manager VM checks. Original creation of this script uses 
 # CAS Manager SaaS deployment var files.
 #
-# Last Updated: 07/15/2022
+# Last Updated: 07/18/2022
 
 import subprocess
 import time
@@ -30,6 +30,20 @@ REGIONS=["eastus", "eastus2", "southcentralus", "westus2", "westus3", "australia
          "southindia", "westindia", "canadaeast", "francesouth", "germanynorth", "norwaywest", "switzerlandwest", "ukwest",
          "uaecentral", "brazilsoutheast"]
 
+# List of deployment offerings
+DEPLOYMENTS=["cas-mgr-load-balancer-one-ip-nat",
+             "cas-mgr-one-ip-traffic-mgr",
+             "cas-mgr-single-connector",
+             "casm-aadds",
+             "casm-aadds-one-ip-lb",
+             "casm-aadds-one-ip-traffic-manager",
+             "casm-aadds-single-connector",
+             "lls-single-connector",
+             "load-balancer-one-ip",
+             "multi-region-traffic-mgr-one-ip",
+             "quickstart-single-connector",
+             "single-connector"]
+
 # General logging of process
 LOG_FILE = "sku_availability_check.log"
 
@@ -46,6 +60,10 @@ CAC_VM_SIZE_SET_FILE = "./modules/cac/cac-vm/main.tf"
 CASM_VM_SIZE_SET_FILE = "./modules/cas-mgr/main.tf"
 DC_VM_SIZE_SET_FILE = "./modules/dc/dc-vm/main.tf"
 
+# Priority list of possible SKU sizes for Windows/Linux Standard Workstations (NOTE: prepend selected terraform.tfvars size to this list when checking availability)
+STANDARD_SKUS_PRIORITY = ["Standard_B2s", "Standard_B2ms", "Standard_D2s_v3", "Standard_B4ms", "Standard_DS2_v2", "Standard_D4s_v3", "Standard_B8ms", "Standard_DS3_v2"]
+GFX_SKUS_PRIORITY = ["Standard_NV4as_v4", "Standard_NV6"]
+
 class MissingLocationError(Exception):
     pass
 
@@ -61,28 +79,22 @@ def log(msg):
     temp.close()
     print(msg)
 
-def extract_default_sizes(vm_type):
-    SIZE_FILE = None
-    VAR_LINE = ""
+
+def extract_default_sizes(vm_type, extract_file):
+    VAR_LINES = []
 
     if vm_type == "CAC":
-        SIZE_FILE = DEFAULT_CAC_VM_SIZE_FILE
-        VAR_LINE = "variable \"machine_type\""
+        VAR_LINES = ["variable \"machine_type\"", "variable \"cac_machine_type\""]
     if vm_type == "CAS Manager":
-        SIZE_FILE = DEFAULT_CASM_VM_SIZE_FILE
-        VAR_LINE = "variable \"machine_type\""
+        VAR_LINES = ["variable \"machine_type\""]
     if vm_type == "DC":
-        SIZE_FILE = DEFAULT_DC_VM_SIZE_FILE
-        VAR_LINE = "variable \"dc_machine_type\""
+        VAR_LINES = ["variable \"dc_machine_type\""]
 
-    default_size_file = open(SIZE_FILE, 'r')
+    default_size_file = open(extract_file, 'r')
     in_var_block = False
     vm_sizes = []
 
     for line in default_size_file:
-        if line.find(VAR_LINE) != -1:
-            in_var_block = True
-            continue
         if line.find("default") != -1 and in_var_block and (line.find("#") == -1 or line.find("#") > line.find("default")):
             vm_sizes = line[line.index("[")+1:line.index("]")].replace("[", "").replace("]", "").replace(", ", " ").replace("\"", "").split(" ")
             log("Default values found for " + vm_type + ": " + str(vm_sizes))
@@ -90,7 +102,23 @@ def extract_default_sizes(vm_type):
         if line.find("\}") != -1 and in_var_block:
             log("Did not find any set values for the " + vm_type + ".")
             raise MissingDefaultSizesError()
+
+        if not in_var_block:
+            for i in range(len(VAR_LINES)):
+                if line.find(VAR_LINES[i]) != -1:
+                    in_var_block = True
+                    break
     return vm_sizes
+
+
+def update_sku_selection(vm_type, location, extract_file, edit_file):
+    log("Finding default SKU sizes for " + vm_type + " VM...")
+    sizes = extract_default_sizes(vm_type, extract_file)
+    log("Checking availability of default " + vm_type + " VM sizes...")
+    check_sku_sizes(sizes, location)
+    available_sku_idx = determine_sku_size(vm_type, sizes)
+    log("Setting VM size index for " + vm_type + " VM...")
+    set_sku_size(edit_file, available_sku_idx)
 
 
 def check_sku_sizes(vm_sizes, location):
@@ -111,21 +139,26 @@ def determine_sku_size(vm_type, vm_sizes):
 
     log("Determining available size for " + vm_type + " under current Azure subscription...")
     for i in range(len(vm_sizes)):
+        sku_file.seek(0)
         for line in sku_file:
             if line.find(vm_sizes[i]) != -1:
                 if line.find("NotAvailableForSubscription") != -1:
-                    log("SKU size " + vm_sizes[i] + " is not available for this subscription")
+                    log("SKU size " + vm_sizes[i] + " is not available for this subscription in the current location")
                     break
                 sku_file.close()
                 log("SKU size " + vm_sizes[i] + " is highest priority for " + vm_type + " that is available")
                 return i
     
     log("SKU sizes for " + vm_type + " did not return any information. Please check the list of sizes requested for this component or the region to search.")
+    sku_file.close()
     raise InvalidSKUSizeError()
 
+
 def set_sku_size(set_file, idx):
-    edit_file = open(set_file, "r")
+    edit_file = open(set_file, "r+")
     replacement = ""
+
+    line_len = None
     for line in edit_file:
         changes = re.sub('var.machine_type\[[0-9]*\]', 'var.machine_type[' + str(idx) + ']', line)
         changes_cac = re.sub('var.cac_machine_type\[[0-9]*\]', 'var.cac_machine_type[' + str(idx) + ']', line)
@@ -139,58 +172,87 @@ def set_sku_size(set_file, idx):
             continue
         replacement += changes
         
+    edit_file.seek(0)
+    edit_file.write(replacement)
     edit_file.close()
 
-    edit_filewrite = open(set_file, "w")
-    edit_filewrite.write(replacement)
-    edit_filewrite.close()
-
     log("File edit complete. Changes may be verified in " + set_file)
+
+# TODO: set files to edit
+def assign_filenames(deployment):
+    if deployment == "cas-mgr-single-connector":
+        # DEFAULT_CAC_VM_SIZE_FILE = "./modules/cac/cac-vm/default-vars.tf"
+        # DEFAULT_CASM_VM_SIZE_FILE = "./modules/cas-mgr/vars.tf"
+        # DEFAULT_DC_VM_SIZE_FILE = "./modules/dc/dc-vm/default-vars.tf"
+        # CAC_VM_SIZE_SET_FILE = "./modules/cac/cac-vm/main.tf"
+        # CASM_VM_SIZE_SET_FILE = "./modules/cas-mgr/main.tf"
+        # DC_VM_SIZE_SET_FILE = "./modules/dc/dc-vm/main.tf"
+        pass
+    if deployment == "cas-mgr-load-balancer-one-ip-nat":
+        pass
+    if deployment == "cas-mgr-one-ip-traffic-mgr":
+        pass
+    if deployment == "casm-aadds":
+        pass
+    if deployment == "casm-aadds-one-ip-lb":
+        pass
+    if deployment == "casm-aadds-one-ip-traffic-manager":
+        pass
+    if deployment == "casm-aadds-single-connector":
+        pass
+    if deployment == "lls-single-connector":
+        pass
+    if deployment == "load-balancer-one-ip":
+        pass
+    if deployment == "multi-region-traffic-mgr-one-ip":
+        pass
+    if deployment == "quickstart-single-connector":
+        pass
+    if deployment == "single-connector":
+        pass
+
 
 def main():
     # Define parameters
     # - location (required) : the region in which to check for SKU sizes; this should be specified as the same as the desired workstations' region
     # - no_casm_vm          : whether or not the deployment will include CAS Manager as a separate VM; specify when indicating using CASM SaaS or other
     # - no_ldc              : whether or not the deployment will require a Local Domain Controller; specify when indicating using Azure AD Domain Services
+    # - deployment          : the specific deployment type intended to be checked for future use; overrides no_casm_vm and no_ldc variables
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-l", "--location", metavar="AAA", choices=REGIONS, required=True, help="Region to check for VM sizes")
     parser.add_argument("--no-casm-vm", default=False, dest="no_casm_vm", 
                         action='store_true', help="Flag for CAS Manager VM; True when using SaaS")
     parser.add_argument("--no-ldc", default=False, dest="no_ldc", action='store_true', help="Flag for DC VM; True when using AADDS")
+    parser.add_argument("-d", "--deployment", dest="deployment", metavar="BBB", choices=DEPLOYMENTS, help="Specific deployment option, overrides --no-casm-vm and --no-ldc")
     args = parser.parse_args()
+
+    assign_filenames(args.deployment)
 
     open(VM_AVAILABILITY_FILE, "a+").close()
 
     log("Querying for SKU sizes in location \"" + args.location + "\"")
     # TODO: should be taking from cac/cac-vm/
     # ... this varies depending on the deployment type, should we add a param for deployment types
-    log("Finding default SKU sizes for CAC-VM...")
-    cac_sizes = extract_default_sizes("CAC")
-    log("Checking availability of default CAC VM sizes...")
-    check_sku_sizes(cac_sizes, args.location)
-    available_sku_idx = determine_sku_size("CAC", cac_sizes)
-    log("Setting VM size index for CAC VM...")
-    set_sku_size(CAC_VM_SIZE_SET_FILE, available_sku_idx)
+    update_sku_selection("CAC", args.location, DEFAULT_CAC_VM_SIZE_FILE, CAC_VM_SIZE_SET_FILE)
 
-    if not args.no_casm_vm:
-        # TODO: should be going from modules/cas-mgr-* based on deployment
-        log("Finding default SKU sizes for CAS Manager VM...")
-        casm_sizes = extract_default_sizes("CAS Manager")
-        log("Checking availability of default CAS Manager VM sizes...")
-        check_sku_sizes(casm_sizes, args.location)
-        available_sku_idx = determine_sku_size("CAS Manager", casm_sizes)
-        log("Setting VM size index for CAS Manager VM...")
-        set_sku_size(CASM_VM_SIZE_SET_FILE, available_sku_idx)
+    if not args.deployment:
+        if not args.no_casm_vm:
+            # TODO: should be going from modules/cas-mgr-* based on deployment
+            update_sku_selection("CAS Manager", args.location, DEFAULT_CASM_VM_SIZE_FILE, CASM_VM_SIZE_SET_FILE)
+            
 
-    if not args.no_ldc:
-        log("Finding default SKU sizes for Domain Controller VM...")
-        dc_sizes = extract_default_sizes("DC")
-        log("Checking availability of default Domain Controller VM sizes...")
-        check_sku_sizes(dc_sizes, args.location)
-        available_sku_idx = determine_sku_size("DC", dc_sizes)
-        log("Setting VM size index for Domain Controller...")
-        set_sku_size(DC_VM_SIZE_SET_FILE, available_sku_idx)
+        if not args.no_ldc:
+            update_sku_selection("DC", args.location, DEFAULT_DC_VM_SIZE_FILE, DC_VM_SIZE_SET_FILE)
+
+    else:
+        # Time to check the terraform.tfvars of the deployment to check for workstation-selected SKUs
+        log("Selected deployment type: " + args.deployment)
+        log("Determining selected workstation SKUs for your deployment. Corresponding directory must contain a terraform.tfvars file and it should be renamed to remove the .sample extension.")
+        tfvars_file = open("./deployments/" + args.deployment + "/terraform.tfvars", "r")
+
+        tfvars_file.close()
+
 
     subprocess.run(["rm", VM_AVAILABILITY_FILE])
     log("SKU availability check completed.\n")

--- a/terraform-deployments/check_sku_avail.py
+++ b/terraform-deployments/check_sku_avail.py
@@ -313,11 +313,29 @@ def assign_filenames(deployment):
         CASM_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/cas-mgr-lb-nat/main.tf"]
 
     if deployment == "casm-aadds-one-ip-lb":
-        pass
+
+        DEFAULT_CAC_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cac-regional/vars.tf", PATH_TO_DIR + "/modules/cac-regional-private-lb-nat/vars.tf"]
+        CAC_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/cac-regional/main.tf", PATH_TO_DIR + "/modules/cac-regional-private-lb-nat/main.tf"]
+        
+        DEFAULT_CASM_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/casm/casm-vm-lb-nat/vars.tf"]
+        CASM_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/casm/casm-vm-lb-nat/main.tf"]
+
     if deployment == "casm-aadds-one-ip-traffic-manager":
-        pass
+
+        DEFAULT_CAC_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cac-regional/vars.tf", PATH_TO_DIR + "/modules/cac-regional-private-lb-nat/vars.tf"]
+        CAC_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/cac-regional/main.tf", PATH_TO_DIR + "/modules/cac-regional-private-lb-nat/main.tf"]
+
+        DEFAULT_CASM_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/casm/casm-vm-lb-nat/vars.tf"]
+        CASM_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/casm/casm-vm-lb-nat/main.tf"]
+
     if deployment == "casm-aadds-single-connector":
-        pass
+
+        DEFAULT_CAC_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cac-regional/vars.tf", PATH_TO_DIR + "/modules/cac-regional-private/vars.tf"]
+        CAC_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/cac-regional/main.tf", PATH_TO_DIR + "/modules/cac-regional-private/main.tf"]
+
+        DEFAULT_CASM_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/casm/casm-vm/vars.tf"]
+        CASM_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/casm/casm-vm/main.tf"]
+
     if deployment == "lls-single-connector":
         pass
     if deployment == "load-balancer-one-ip":
@@ -347,25 +365,26 @@ def main():
     args = parser.parse_args()
 
     open(VM_AVAILABILITY_FILE, "a+").close()
-    
+
+    log("Selected deployment type: " + args.deployment)
+
     if args.all:
         assign_filenames(args.deployment)
 
         log("Querying for SKU sizes in location \"" + args.location + "\"")
-        log("Selected deployment type: " + args.deployment)
         
         for a in range(len(DEFAULT_CAC_VM_SIZE_FILES)):
             update_sku_selection("CAC", args.location, DEFAULT_CAC_VM_SIZE_FILES[a], CAC_VM_SIZE_SET_FILES[a])
 
         if args.deployment in ["cas-mgr-single-connector", "cas-mgr-load-balancer-one-ip-nat", "cas-mgr-one-ip-traffic-mgr", 
-                            "casm-aadds-single-connector", "casm-aadds-one-ip-lb", "casm-aadds-one-ip-traffic-manager"]:
+                               "casm-aadds-single-connector", "casm-aadds-one-ip-lb", "casm-aadds-one-ip-traffic-manager"]:
             if not args.no_casm_vm:
                 for b in range(len(DEFAULT_CASM_VM_SIZE_FILES)):
                     update_sku_selection("CAS Manager", args.location, DEFAULT_CASM_VM_SIZE_FILES[b], CASM_VM_SIZE_SET_FILES[b])
 
         if args.deployment in ["cas-mgr-single-connector", "cas-mgr-load-balancer-one-ip-nat", "cas-mgr-one-ip-traffic-mgr",
-                            "lls-single-connector", "load-balancer-one-ip", "multi-region-traffic-mgr-one-ip", "quickstart-single-connector",
-                            "single-connector"]:
+                               "lls-single-connector", "load-balancer-one-ip", "multi-region-traffic-mgr-one-ip", "quickstart-single-connector",
+                               "single-connector"]:
             if not args.no_ldc:
                 for c in range(len(DEFAULT_DC_VM_SIZE_FILES)):
                     update_sku_selection("DC", args.location, DEFAULT_DC_VM_SIZE_FILES[c], DC_VM_SIZE_SET_FILES[c])

--- a/terraform-deployments/check_sku_avail.py
+++ b/terraform-deployments/check_sku_avail.py
@@ -14,7 +14,7 @@
 # certain files. Please ensure that as much as possible when making changes to variables or .tfvars files that
 # only necessary changes are made, and that whitespace structure is maintained before running this script.
 #
-# Last Updated: 07/26/2022
+# Last Updated: 07/27/2022
 
 import subprocess
 import time
@@ -38,7 +38,7 @@ REGIONS=["eastus", "eastus2", "southcentralus", "westus2", "westus3", "australia
          "southindia", "westindia", "canadaeast", "francesouth", "germanynorth", "norwaywest", "switzerlandwest", "ukwest",
          "uaecentral", "brazilsoutheast"]
 
-# List of deployment offerings
+# List of deployment offerings (EXCLUDES CASM-AADDS and QUICKSTART)
 DEPLOYMENTS=["cas-mgr-load-balancer-one-ip-nat",
              "cas-mgr-one-ip-traffic-mgr",
              "cas-mgr-single-connector",
@@ -48,7 +48,6 @@ DEPLOYMENTS=["cas-mgr-load-balancer-one-ip-nat",
              "lls-single-connector",
              "load-balancer-one-ip",
              "multi-region-traffic-mgr-one-ip",
-             "quickstart-single-connector",
              "single-connector"]
 
 # General logging of process
@@ -295,19 +294,15 @@ def update_workstations_for_deployment(deployment, sizes):
     tfvars.close()
 
 
-# TODO: set files to edit
 def assign_filenames(deployment):
     global DEFAULT_CAC_VM_SIZE_FILES
     global DEFAULT_CASM_VM_SIZE_FILES
-    global DEFAULT_DC_VM_SIZE_FILES
-
     global CAC_VM_SIZE_SET_FILES
     global CASM_VM_SIZE_SET_FILES
-    global DC_VM_SIZE_SET_FILES
 
     if deployment == "cas-mgr-single-connector":
        # Same as global variable initial values
-       pass
+       return
     if deployment == "cas-mgr-load-balancer-one-ip-nat":
 
         DEFAULT_CAC_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cac-regional/vars.tf", PATH_TO_DIR + "/modules/cac-regional-private-lb-nat/vars.tf"]
@@ -315,7 +310,7 @@ def assign_filenames(deployment):
 
         DEFAULT_CASM_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cas-mgr-lb-nat/vars.tf"]
         CASM_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/cas-mgr-lb-nat/main.tf"]
-
+        return
     if deployment == "cas-mgr-one-ip-traffic-mgr":
         
         DEFAULT_CAC_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cac-regional/vars.tf", PATH_TO_DIR + "/modules/cac-regional-private-lb-nat/vars.tf"]
@@ -323,7 +318,7 @@ def assign_filenames(deployment):
 
         DEFAULT_CASM_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cas-mgr-lb-nat/vars.tf"]
         CASM_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/cas-mgr-lb-nat/main.tf"]
-
+        return
     if deployment == "casm-aadds-one-ip-lb":
 
         DEFAULT_CAC_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cac-regional/vars.tf", PATH_TO_DIR + "/modules/cac-regional-private-lb-nat/vars.tf"]
@@ -331,7 +326,7 @@ def assign_filenames(deployment):
         
         DEFAULT_CASM_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/casm/casm-vm-lb-nat/vars.tf"]
         CASM_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/casm/casm-vm-lb-nat/main.tf"]
-
+        return
     if deployment == "casm-aadds-one-ip-traffic-manager":
 
         DEFAULT_CAC_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cac-regional/vars.tf", PATH_TO_DIR + "/modules/cac-regional-private-lb-nat/vars.tf"]
@@ -339,7 +334,7 @@ def assign_filenames(deployment):
 
         DEFAULT_CASM_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/casm/casm-vm-lb-nat/vars.tf"]
         CASM_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/casm/casm-vm-lb-nat/main.tf"]
-
+        return
     if deployment == "casm-aadds-single-connector":
 
         DEFAULT_CAC_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cac-regional/vars.tf", PATH_TO_DIR + "/modules/cac-regional-private/vars.tf"]
@@ -347,17 +342,26 @@ def assign_filenames(deployment):
 
         DEFAULT_CASM_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/casm/casm-vm/vars.tf"]
         CASM_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/casm/casm-vm/main.tf"]
-
+        return
     if deployment == "lls-single-connector":
-        pass
+
+        DEFAULT_CAC_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cac/cac-vm/default-vars.tf"]
+        CAC_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/cac/cac-vm/main.tf"]
+        return
     if deployment == "load-balancer-one-ip":
-        pass
+
+        DEFAULT_CAC_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cac/cac-vm-lb-nat/default-vars.tf"]
+        CAC_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/cac/cac-vm-lb-nat/main.tf"]
+        return
     if deployment == "multi-region-traffic-mgr-one-ip":
-        pass
-    if deployment == "quickstart-single-connector":
-        pass
+
+        DEFAULT_CAC_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cac/cac-vm-tm-nat/default-vars.tf"]
+        CAC_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/cac/cac-vm-tm-nat/main.tf"]
+        return
     if deployment == "single-connector":
-        pass
+
+        DEFAULT_CAC_VM_SIZE_FILES = [PATH_TO_DIR + "/modules/cac/cac-vm/default-vars.tf"]
+        CAC_VM_SIZE_SET_FILES = [PATH_TO_DIR + "/modules/cac/cac-vm/main.tf"]
 
 
 def main():
@@ -400,6 +404,9 @@ def main():
             if not args.no_ldc:
                 for c in range(len(DEFAULT_DC_VM_SIZE_FILES)):
                     update_sku_selection("DC", args.location, DEFAULT_DC_VM_SIZE_FILES[c], DC_VM_SIZE_SET_FILES[c])
+
+        if args.deployment == "lls-single-connector":
+            update_sku_selection("LLS", args.location, PATH_TO_DIR + "/modules/lls/vars.tf", PATH_TO_DIR + "/modules/lls/main.tf")
 
     # Time to check the terraform.tfvars of the deployment to check for workstation-selected SKUs
     log("Determining selected workstation SKUs for your deployment. Corresponding directory must contain a terraform.tfvars file and it should be renamed to remove the .sample extension.")

--- a/terraform-deployments/check_sku_avail.py
+++ b/terraform-deployments/check_sku_avail.py
@@ -6,10 +6,13 @@
 # This script is meant to be run within the environment of the Azure Cloud Shell, and is not intended to be run
 # in a local environment.
 #
-# TODO: add more flexibiility to CAC and CAS Manager VM checks. Original creation of this script uses 
-# CAS Manager SaaS deployment var files.
+# By default, the program will check for the SKU sizes being selected pertaining to the 
+# CAS Manager Single Connector Standalone deployment.
+# Other deployment types can be specified on the command line when executing
 #
-# Last Updated: 07/18/2022
+# TODO: add more flexibiility to CAC and CAS Manager VM checks.
+#
+# Last Updated: 07/20/2022
 
 import subprocess
 import time

--- a/terraform-deployments/check_sku_avail.py
+++ b/terraform-deployments/check_sku_avail.py
@@ -14,7 +14,7 @@
 # certain files. Please ensure that as much as possible when making changes to variables or .tfvars files that
 # only necessary changes are made, and that whitespace structure is maintained before running this script.
 #
-# Last Updated: 07/25/2022
+# Last Updated: 07/26/2022
 
 import subprocess
 import time
@@ -131,14 +131,26 @@ def update_sku_selection(vm_type, location, extract_file, edit_file):
 
 def check_sku_sizes(vm_sizes, location):
     sku_file = open(VM_AVAILABILITY_FILE, "w")
+
+    valid_size_found = False
     for i in range(len(vm_sizes)):
         log("-- Checking availability of VM size " + vm_sizes[i])
-        sku_file.write(str(subprocess.check_output(["az", "vm", "list-skus", "--location", location, 
+        results = str(subprocess.check_output(["az", "vm", "list-skus", "--location", location, 
                                                                              "--size", vm_sizes[i], 
                                                                              "--all", 
-                                                                             "--output", "table"])).replace("\\n", '\n'))
+                                                                             "--output", "table"])).replace("\\n", '\n')
+        sku_file.write(results)
+        results_list = results.split('\n')
+        for r in results_list:
+            if r.find(vm_sizes[i]) != -1:
+                if r.find("NotAvailableForSubscription") == -1:
+                    valid_size_found = True
+                break
         # Separate the output of one command from the next
         sku_file.write('\n')
+
+        if valid_size_found:
+            break
     sku_file.close()
 
 

--- a/terraform-deployments/deployments/lls-single-connector/default-vars.tf
+++ b/terraform-deployments/deployments/lls-single-connector/default-vars.tf
@@ -45,11 +45,6 @@ variable "resource_group_name" {
   default     = ""
 }
 
-variable "cac_machine_type" {
-  description = "Machine type for the Cloud Access Connector"
-  default     = "Standard_D2s_v3"
-}
-
 variable "ssl_key" {
   description = "SSL private key for the Connector"
   default     = ""
@@ -58,11 +53,6 @@ variable "ssl_key" {
 variable "ssl_cert" {
   description = "SSL certificate for the Connector"
   default     = ""
-}
-
-variable "dc_machine_type" {
-  description = "Machine type for Domain Controller"
-  default     = "Standard_F2"
 }
 
 variable "ad_domain_users_list_file" {

--- a/terraform-deployments/deployments/lls-single-connector/main.tf
+++ b/terraform-deployments/deployments/lls-single-connector/main.tf
@@ -81,7 +81,6 @@ module "active-directory-domain-vm" {
   ad_admin_password            = var.ad_admin_password
   ad_pass_secret_name          = var.ad_pass_secret_name
   key_vault_id                 = var.key_vault_id
-  dc_machine_type              = var.dc_machine_type
   nic_id                       = module.dc-cac-network.dc-network-interface-id
   prefix                       = var.prefix
   application_id               = var.application_id
@@ -145,7 +144,6 @@ module "cac-vm" {
   ad_service_account_username = var.ad_admin_username
   ad_service_account_password = var.ad_admin_password
   nic_ids                     = module.cac-network.cac-network-interface-ids
-  machine_type                = var.cac_machine_type
   cac_admin_user              = var.cac_admin_username
   cac_admin_password          = var.ad_admin_password
   dns_zone_id                 = module.dc-cac-network.private-dns-zone-id

--- a/terraform-deployments/deployments/load-balancer-one-ip/default-vars.tf
+++ b/terraform-deployments/deployments/load-balancer-one-ip/default-vars.tf
@@ -60,11 +60,6 @@ variable "resource_group_name" {
   default     = ""
 }
 
-variable "cac_machine_type" {
-  description = "Machine type for the Cloud Access Connector"
-  default     = "Standard_D2s_v3"
-}
-
 variable "disk_size_gb" {
   description = "Disk size (GB) of the Cloud Access Connector"
   default     = "50"
@@ -78,11 +73,6 @@ variable "ssl_key" {
 variable "ssl_cert" {
   description = "SSL certificate for the Connector"
   default     = ""
-}
-
-variable "dc_machine_type" {
-  description = "Machine type for Domain Controller"
-  default     = "Standard_F2"
 }
 
 variable "ad_domain_users_list_file" {

--- a/terraform-deployments/deployments/load-balancer-one-ip/main.tf
+++ b/terraform-deployments/deployments/load-balancer-one-ip/main.tf
@@ -95,7 +95,6 @@ module "active-directory-domain-vm" {
   ad_admin_password            = var.ad_admin_password
   ad_pass_secret_name          = var.ad_pass_secret_name
   key_vault_id                 = var.key_vault_id
-  dc_machine_type              = var.dc_machine_type
   nic_id                       = module.dc-cac-network.dc-network-interface-id
   prefix                       = var.prefix
   application_id               = var.application_id
@@ -159,7 +158,6 @@ module "cac-vm" {
   ad_service_account_username = var.ad_admin_username
   ad_service_account_password = var.ad_admin_password
   nic_ids                     = module.cac-network.cac-network-interface-ids
-  machine_type                = var.cac_machine_type
   cac_admin_user              = var.cac_admin_username
   cac_admin_password          = var.ad_admin_password
   dns_zone_id                 = module.dc-cac-network.private-dns-zone-id

--- a/terraform-deployments/deployments/multi-region-traffic-mgr-one-ip/default-vars.tf
+++ b/terraform-deployments/deployments/multi-region-traffic-mgr-one-ip/default-vars.tf
@@ -15,11 +15,6 @@ variable "cac_admin_username" {
   default     = "cas_admin"
 }
 
-variable "cac_machine_type" {
-  description = "Machine type for the Cloud Access Connector"
-  default     = "Standard_D2s_v3"
-}
-
 variable "windows_admin_username" {
   description = "Name for the Windows Administrator of the Workstation"
   default     = "windows_admin"

--- a/terraform-deployments/deployments/multi-region-traffic-mgr-one-ip/main.tf
+++ b/terraform-deployments/deployments/multi-region-traffic-mgr-one-ip/main.tf
@@ -70,7 +70,6 @@ module "cac-vm" {
   ad_service_account_username = var.ad_admin_username
   ad_service_account_password = var.ad_admin_password
   nic_ids                     = module.cac-network[count.index].cac-network-interface-ids
-  machine_type                = var.cac_machine_type
   cac_admin_user              = var.cac_admin_username
   cac_admin_password          = var.ad_admin_password
   dns_zone_id                 = module.dc-cac-network.private-dns-zone-id

--- a/terraform-deployments/deployments/single-connector/default-vars.tf
+++ b/terraform-deployments/deployments/single-connector/default-vars.tf
@@ -50,11 +50,6 @@ variable "resource_group_name" {
   default     = ""
 }
 
-variable "cac_machine_type" {
-  description = "Machine type for the Cloud Access Connector"
-  default     = "Standard_D2s_v3"
-}
-
 variable "ssl_key" {
   description = "SSL private key for the Connector"
   default     = ""
@@ -68,11 +63,6 @@ variable "ssl_cert" {
 variable "vnet_name" {
   description = "Prefix to add to name of new resources. Must be <= 9 characters."
   default     = "vnet"
-}
-
-variable "dc_machine_type" {
-  description = "Machine type for Domain Controller"
-  default     = "Standard_F2"
 }
 
 variable "ad_domain_users_list_file" {

--- a/terraform-deployments/deployments/single-connector/main.tf
+++ b/terraform-deployments/deployments/single-connector/main.tf
@@ -84,7 +84,6 @@ module "active-directory-domain-vm" {
   ad_admin_password            = var.ad_admin_password
   ad_pass_secret_name          = var.ad_pass_secret_name
   key_vault_id                 = var.key_vault_id
-  dc_machine_type              = var.dc_machine_type
   nic_id                       = module.dc-cac-network.dc-network-interface-id
   prefix                       = var.prefix
   application_id               = var.application_id
@@ -148,7 +147,6 @@ module "cac-vm" {
   ad_service_account_username = var.ad_admin_username
   ad_service_account_password = var.ad_admin_password
   nic_ids                     = module.cac-network.cac-network-interface-ids
-  machine_type                = var.cac_machine_type
   cac_admin_user              = var.cac_admin_username
   cac_admin_password          = var.ad_admin_password
   dns_zone_id                 = module.dc-cac-network.private-dns-zone-id

--- a/terraform-deployments/modules/cac-cas-mgr/vars.tf
+++ b/terraform-deployments/modules/cac-cas-mgr/vars.tf
@@ -118,11 +118,6 @@ variable "locations" {
   type        = list(string)
 }
 
-variable "machine_type" {
-  description = "Machine type for the Cloud Access Connector"
-  default     = "Standard_B2ms"
-}
-
 variable "network_security_group_ids" {
   description = "List of network security group ids"
   type        = list(string)

--- a/terraform-deployments/modules/cac-regional-private-lb-nat/main.tf
+++ b/terraform-deployments/modules/cac-regional-private-lb-nat/main.tf
@@ -83,7 +83,7 @@ resource "azurerm_linux_virtual_machine" "cac-vm" {
   name                            = "${local.prefix}cac-vm-${var.location}-${count.index}"
   location                        = var.location
   resource_group_name             = var.resource_group_name
-  size                            = var.machine_type
+  size                            = var.machine_type[0]
   admin_username                  = var.cac_admin_user
   admin_password                  = local.cac_admin_password
   computer_name                   = "${local.prefix}cac-vm"

--- a/terraform-deployments/modules/cac-regional-private-lb-nat/vars.tf
+++ b/terraform-deployments/modules/cac-regional-private-lb-nat/vars.tf
@@ -130,7 +130,7 @@ variable "location" {
 
 variable "machine_type" {
   description = "Machine type for the Cloud Access Connector"
-  default     = "Standard_B2ms"
+  default     = ["Standard_B2ms"]
 }
 
 variable "network_security_group_id" {

--- a/terraform-deployments/modules/cac-regional-private-lb-nat/vars.tf
+++ b/terraform-deployments/modules/cac-regional-private-lb-nat/vars.tf
@@ -130,7 +130,7 @@ variable "location" {
 
 variable "machine_type" {
   description = "Machine type for the Cloud Access Connector"
-  default     = ["Standard_B2ms"]
+  default     = ["Standard_D2s_v3", "Standard_B2ms"]
 }
 
 variable "network_security_group_id" {

--- a/terraform-deployments/modules/cac-regional-private/main.tf
+++ b/terraform-deployments/modules/cac-regional-private/main.tf
@@ -83,7 +83,7 @@ resource "azurerm_linux_virtual_machine" "cac-vm" {
   name                            = "${local.prefix}cac-vm-${var.location}-${count.index}"
   location                        = var.location
   resource_group_name             = var.resource_group_name
-  size                            = var.machine_type
+  size                            = var.machine_type[0]
   admin_username                  = var.cac_admin_user
   admin_password                  = local.cac_admin_password
   computer_name                   = "${local.prefix}cac-vm"

--- a/terraform-deployments/modules/cac-regional-private/vars.tf
+++ b/terraform-deployments/modules/cac-regional-private/vars.tf
@@ -130,7 +130,7 @@ variable "location" {
 
 variable "machine_type" {
   description = "Machine type for the Cloud Access Connector"
-  default     = "Standard_B2ms"
+  default     = ["Standard_B2ms"]
 }
 
 variable "network_security_group_id" {

--- a/terraform-deployments/modules/cac-regional-private/vars.tf
+++ b/terraform-deployments/modules/cac-regional-private/vars.tf
@@ -130,7 +130,7 @@ variable "location" {
 
 variable "machine_type" {
   description = "Machine type for the Cloud Access Connector"
-  default     = ["Standard_B2ms"]
+  default     = ["Standard_D2s_v3", "Standard_B2ms"]
 }
 
 variable "network_security_group_id" {

--- a/terraform-deployments/modules/cac-regional/main.tf
+++ b/terraform-deployments/modules/cac-regional/main.tf
@@ -103,7 +103,7 @@ resource "azurerm_linux_virtual_machine" "cac-vm" {
   name                            = "${local.prefix}cac-vm-${var.location}-${count.index}"
   location                        = var.location
   resource_group_name             = var.resource_group_name
-  size                            = var.machine_type
+  size                            = var.machine_type[0]
   admin_username                  = var.cac_admin_user
   admin_password                  = local.cac_admin_password
   computer_name                   = "${local.prefix}cac-vm"

--- a/terraform-deployments/modules/cac-regional/vars.tf
+++ b/terraform-deployments/modules/cac-regional/vars.tf
@@ -130,7 +130,7 @@ variable "location" {
 
 variable "machine_type" {
   description = "Machine type for the Cloud Access Connector"
-  default     = "Standard_B2ms"
+  default     = ["Standard_B2ms"]
 }
 
 variable "network_security_group_id" {

--- a/terraform-deployments/modules/cac-regional/vars.tf
+++ b/terraform-deployments/modules/cac-regional/vars.tf
@@ -130,7 +130,7 @@ variable "location" {
 
 variable "machine_type" {
   description = "Machine type for the Cloud Access Connector"
-  default     = ["Standard_B2ms"]
+  default     = ["Standard_D2s_v3", "Standard_B2ms"]
 }
 
 variable "network_security_group_id" {

--- a/terraform-deployments/modules/cac/cac-vm-lb-nat/default-vars.tf
+++ b/terraform-deployments/modules/cac/cac-vm-lb-nat/default-vars.tf
@@ -28,7 +28,7 @@ variable "location" {
 
 variable "machine_type" {
   description = "Machine type for the Cloud Access Connector"
-  default     = ["Standard_B2ms"]
+  default     = ["Standard_D2s_v3", "Standard_B2ms"]
 }
 
 variable "disk_size_gb" {

--- a/terraform-deployments/modules/cac/cac-vm-lb-nat/default-vars.tf
+++ b/terraform-deployments/modules/cac/cac-vm-lb-nat/default-vars.tf
@@ -28,7 +28,7 @@ variable "location" {
 
 variable "machine_type" {
   description = "Machine type for the Cloud Access Connector"
-  default     = "Standard_B2ms"
+  default     = ["Standard_B2ms"]
 }
 
 variable "disk_size_gb" {

--- a/terraform-deployments/modules/cac/cac-vm-lb-nat/main.tf
+++ b/terraform-deployments/modules/cac/cac-vm-lb-nat/main.tf
@@ -27,7 +27,7 @@ resource "azurerm_linux_virtual_machine" "cac" {
   name                            = "${local.prefix}cac-vm-${count.index}"
   location                        = var.cac_configuration[count.index].location
   resource_group_name             = var.resource_group_name
-  size                            = var.machine_type
+  size                            = var.machine_type[0]
   admin_username                  = var.cac_admin_user
   admin_password                  = local.cac_admin_password
   computer_name                   = "${local.prefix}cac-vm"

--- a/terraform-deployments/modules/cac/cac-vm-tm-nat/default-vars.tf
+++ b/terraform-deployments/modules/cac/cac-vm-tm-nat/default-vars.tf
@@ -28,7 +28,7 @@ variable "location" {
 
 variable "machine_type" {
   description = "Machine type for the Cloud Access Connector"
-  default     = ["Standard_B2ms"]
+  default     = ["Standard_D2s_v3", "Standard_B2ms"]
 }
 
 variable "disk_size_gb" {

--- a/terraform-deployments/modules/cac/cac-vm-tm-nat/default-vars.tf
+++ b/terraform-deployments/modules/cac/cac-vm-tm-nat/default-vars.tf
@@ -28,7 +28,7 @@ variable "location" {
 
 variable "machine_type" {
   description = "Machine type for the Cloud Access Connector"
-  default     = "Standard_B2ms"
+  default     = ["Standard_B2ms"]
 }
 
 variable "disk_size_gb" {

--- a/terraform-deployments/modules/cac/cac-vm-tm-nat/main.tf
+++ b/terraform-deployments/modules/cac/cac-vm-tm-nat/main.tf
@@ -27,7 +27,7 @@ resource "azurerm_linux_virtual_machine" "cac" {
   name                            = "${local.prefix}cac-vm-${var.location}-${count.index}"
   location                        = var.location
   resource_group_name             = var.resource_group_name
-  size                            = var.machine_type
+  size                            = var.machine_type[0]
   admin_username                  = var.cac_admin_user
   admin_password                  = local.cac_admin_password
   computer_name                   = "${local.prefix}cac-vm"

--- a/terraform-deployments/modules/cac/cac-vm/default-vars.tf
+++ b/terraform-deployments/modules/cac/cac-vm/default-vars.tf
@@ -23,7 +23,7 @@ variable "location" {
 
 variable "machine_type" {
   description = "Machine type for the Cloud Access Connector"
-  default     = "Standard_B2ms"
+  default     = ["Standard_B2ms"]
 }
 
 variable "disk_size_gb" {

--- a/terraform-deployments/modules/cac/cac-vm/default-vars.tf
+++ b/terraform-deployments/modules/cac/cac-vm/default-vars.tf
@@ -23,7 +23,7 @@ variable "location" {
 
 variable "machine_type" {
   description = "Machine type for the Cloud Access Connector"
-  default     = ["Standard_B2ms"]
+  default     = ["Standard_D2s_v3", "Standard_B2ms"]
 }
 
 variable "disk_size_gb" {

--- a/terraform-deployments/modules/cac/cac-vm/main.tf
+++ b/terraform-deployments/modules/cac/cac-vm/main.tf
@@ -27,7 +27,7 @@ resource "azurerm_linux_virtual_machine" "cac" {
   name                            = "${local.prefix}cac-vm-${count.index}"
   location                        = var.cac_configuration[count.index].location
   resource_group_name             = var.resource_group_name
-  size                            = var.machine_type
+  size                            = var.machine_type[0]
   admin_username                  = var.cac_admin_user
   admin_password                  = local.cac_admin_password
   computer_name                   = "${local.prefix}cac-vm"

--- a/terraform-deployments/modules/cas-mgr-lb-nat/main.tf
+++ b/terraform-deployments/modules/cas-mgr-lb-nat/main.tf
@@ -92,7 +92,7 @@ resource "azurerm_linux_virtual_machine" "cas-mgr-vm" {
   admin_username                  = var.ad_service_account_username
   admin_password                  = local.cas_mgr_admin_password
   disable_password_authentication = false
-  size                            = var.machine_type
+  size                            = var.machine_type[0]
 
   network_interface_ids = [
     azurerm_network_interface.cas-mgr-nic.id

--- a/terraform-deployments/modules/cas-mgr-lb-nat/vars.tf
+++ b/terraform-deployments/modules/cas-mgr-lb-nat/vars.tf
@@ -49,7 +49,7 @@ variable "cas_mgr_subnet_depends_on" {
 variable "machine_type" {
   description = "Instance type for the CAS Manager (min 8 GB RAM, 4 vCPUs)"
   # default   = "Standard_F4s_v2"
-  default = "Standard_D2s_v3"
+  default = ["Standard_D2s_v3"]
 }
 
 variable "disk_size_gb" {

--- a/terraform-deployments/modules/cas-mgr/main.tf
+++ b/terraform-deployments/modules/cas-mgr/main.tf
@@ -97,7 +97,7 @@ resource "azurerm_linux_virtual_machine" "cas-mgr-vm" {
   admin_username                  = var.ad_service_account_username
   admin_password                  = local.cas_mgr_admin_password
   disable_password_authentication = false
-  size                            = var.machine_type
+  size                            = var.machine_type[0]
 
   network_interface_ids = [
     azurerm_network_interface.cas-mgr-nic.id

--- a/terraform-deployments/modules/cas-mgr/vars.tf
+++ b/terraform-deployments/modules/cas-mgr/vars.tf
@@ -49,7 +49,7 @@ variable "cas_mgr_subnet_depends_on" {
 variable "machine_type" {
   description = "Instance type for the CAS Manager (min 8 GB RAM, 4 vCPUs)"
   # default   = "Standard_F4s_v2"
-  default = "Standard_D2s_v3"
+  default = ["Standard_D2s_v3"]
 }
 
 variable "disk_size_gb" {

--- a/terraform-deployments/modules/casm/casm-vm-lb-nat/main.tf
+++ b/terraform-deployments/modules/casm/casm-vm-lb-nat/main.tf
@@ -164,7 +164,7 @@ resource "azurerm_linux_virtual_machine" "cas-mgr-vm" {
   admin_username                  = var.ad_service_account_username
   admin_password                  = local.cas_mgr_admin_password
   disable_password_authentication = false
-  size                            = var.machine_type
+  size                            = var.machine_type[0]
 
   network_interface_ids = [
     azurerm_network_interface.cas-mgr-nic.id

--- a/terraform-deployments/modules/casm/casm-vm-lb-nat/vars.tf
+++ b/terraform-deployments/modules/casm/casm-vm-lb-nat/vars.tf
@@ -51,7 +51,7 @@ variable "cas_mgr_deployment_sa_file" {
 variable "machine_type" {
   description = "Instance type for the CAS Manager (min 8 GB RAM, 4 vCPUs)"
   # default   = "Standard_F4s_v2"
-  default = "Standard_D2s_v3"
+  default = ["Standard_D2s_v3"]
 }
 
 variable "disk_size_gb" {

--- a/terraform-deployments/modules/casm/casm-vm/main.tf
+++ b/terraform-deployments/modules/casm/casm-vm/main.tf
@@ -173,7 +173,7 @@ resource "azurerm_linux_virtual_machine" "cas-mgr-vm" {
   admin_username                  = var.ad_service_account_username
   admin_password                  = local.cas_mgr_admin_password
   disable_password_authentication = false
-  size                            = var.machine_type
+  size                            = var.machine_type[0]
 
   network_interface_ids = [
     azurerm_network_interface.cas-mgr-nic.id

--- a/terraform-deployments/modules/casm/casm-vm/vars.tf
+++ b/terraform-deployments/modules/casm/casm-vm/vars.tf
@@ -51,7 +51,7 @@ variable "cas_mgr_deployment_sa_file" {
 variable "machine_type" {
   description = "Instance type for the CAS Manager (min 8 GB RAM, 4 vCPUs)"
   # default   = "Standard_F4s_v2"
-  default = "Standard_D2s_v3"
+  default = ["Standard_D2s_v3"]
 }
 
 variable "disk_size_gb" {

--- a/terraform-deployments/modules/dc/dc-vm/default-vars.tf
+++ b/terraform-deployments/modules/dc/dc-vm/default-vars.tf
@@ -13,7 +13,7 @@ variable "dc_vm_depends_on" {
 
 variable "dc_machine_type" {
   description = "Machine type for Domain Controller"
-  default     = "Standard_F2"
+  default     = ["Standard_F2"]
 }
 
 variable "key_vault_id" {

--- a/terraform-deployments/modules/dc/dc-vm/main.tf
+++ b/terraform-deployments/modules/dc/dc-vm/main.tf
@@ -11,7 +11,7 @@ resource "azurerm_windows_virtual_machine" "domain-controller" {
   name                = local.virtual_machine_name
   resource_group_name = var.resource_group_name
   location            = var.location
-  size                = var.dc_machine_type
+  size                = var.dc_machine_type[0]
   admin_username      = var.ad_admin_username
   admin_password      = local.ad_admin_password
   custom_data         = local.custom_data

--- a/terraform-deployments/modules/lls/main.tf
+++ b/terraform-deployments/modules/lls/main.tf
@@ -53,7 +53,7 @@ resource "azurerm_linux_virtual_machine" "lls-vm" {
   admin_username                  = var.ad_service_account_username
   admin_password                  = local.lls_admin_password
   disable_password_authentication = false
-  size                            = var.machine_type
+  size                            = var.machine_type[0]
 
   network_interface_ids = [
     # azurerm_network_interface.lls-nic[each.key].id

--- a/terraform-deployments/modules/lls/vars.tf
+++ b/terraform-deployments/modules/lls/vars.tf
@@ -22,7 +22,7 @@ variable "ad_service_account_password" {
 
 variable "machine_type" {
   description = "Azure virtual machine size."
-  default     = "Standard_B2ms"
+  default     = ["Standard_B2ms"]
 }
 
 variable "application_id" {


### PR DESCRIPTION
Since we had redundancy in defining var.machine_type for some cac and dc vms for a few deployment types, decided to fully remove the definition from deployments/ folder and allow for sourcing out of modules/ folder.

The variable in deployments/ folder often used "Standard_D2s_v3", and the modules/ copy used "Standard_B2ms". Added the first one to the default priority list for 2 reasons
- preserve possibly the original intended default value placed in the main directory for that deployment and have the Standard_B2ms as backup
- I believe previously Bob mentioned to me that Standard_B2ms is actually not enough for CAC or DC VM and should be upgraded. By doing this, we can still keep that one as the backup while placing a more performant SKU as first priority