### PR TITLE
DC Setup: Enforce TLS 1.2 for Invoke-Restmethod

### DIFF
--- a/terraform-deployments/modules/dc/dc-service/files/setup.ps1
+++ b/terraform-deployments/modules/dc/dc-service/files/setup.ps1
@@ -49,7 +49,7 @@ Function Get-Secret
   
   $headers = @{ 'Authorization' = "Bearer $accessToken"; "Content-Type" = "application/json" }
 
-  $response = Invoke-RestMethod -Method GET -Ur $queryUrl -Headers $headers
+  $response = Invoke-RestMethod -Method GET -Uri $queryUrl -Headers $headers
   
   $result = $response.value
 
@@ -57,6 +57,10 @@ Function Get-Secret
 }
 
 Start-Transcript -path $LOG_FILE -append
+
+# Enforce TLS 1.2 due to Azure deprecation of prior versions
+# TODO: Investigate setting this persistently via registry etc.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 if ([string]::IsNullOrWhiteSpace("${tenant_id}")) {
   Write-Output "Not calling Get-Secret"


### PR DESCRIPTION
Fix DC provisioning failures caused by Azure oauth token request being rejected for not using TLS1.2

Signed-off-by: Daniel Bergel <daniel.bergel@hp.com>